### PR TITLE
fix(browser-use): load AppKit framework before hiding macOS dock icon

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -259,7 +259,7 @@
       "name": "browser-use",
       "source": "./plugins/browser-use",
       "description": "Full-platform browser automation for Claude Code. v1.0.1: Fix macOS dock icon (Python rocket) for MCP server. 18 MCP tools, 5 skills, local CDP + Cloud support.",
-      "version": "1.0.1",
+      "version": "1.0.2",
       "author": {
         "name": "Jack Rudenko",
         "email": "i@madappgang.com",

--- a/plugins/browser-use/plugin.json
+++ b/plugins/browser-use/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "browser-use",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Full-platform browser automation for Claude Code. v1.0.1: Fix macOS dock icon (Python rocket) for MCP server process. 15 MCP tools via in-process asyncio server, 5 skills, local CDP + Cloud support, claude-in-chrome hybrid workflows.",
   "author": {
     "name": "Jack Rudenko",

--- a/plugins/browser-use/scripts/mcp-server.py
+++ b/plugins/browser-use/scripts/mcp-server.py
@@ -31,6 +31,9 @@ if sys.platform == "darwin":
         import ctypes.util
 
         _objc = ctypes.cdll.LoadLibrary(ctypes.util.find_library("objc"))
+        # AppKit must be loaded first — NSApplication isn't available in a bare
+        # Python process until its framework is loaded into the address space.
+        ctypes.cdll.LoadLibrary("/System/Library/Frameworks/AppKit.framework/AppKit")
         _objc.objc_getClass.restype = ctypes.c_void_p
         _objc.sel_registerName.restype = ctypes.c_void_p
         _objc.objc_msgSend.restype = ctypes.c_void_p


### PR DESCRIPTION
## Summary

- The v1.0.1 dock icon fix was silently failing — `NSApplication` class isn't available in a bare Python process because AppKit framework isn't loaded
- Added `ctypes.cdll.LoadLibrary("/System/Library/Frameworks/AppKit.framework/AppKit")` before `objc_getClass(b"NSApplication")`
- `objc_getClass` returned NULL → `objc_msgSend(NULL, ...)` was a no-op → the entire fix chain did nothing
- Bumps browser-use to v1.0.2

## Test plan

- [x] Verified `NSApplication` class resolves to non-None after loading AppKit
- [x] Verified `setActivationPolicy:` returns policy=2 (Prohibited)
- [x] Patched cached v1.0.0 and v1.0.1 for immediate local testing