### PR TITLE
fix(ci): restore claudeup-core to pnpm workspace to fix Test Plugins failures

### DIFF
--- a/tools/pnpm-workspace.yaml
+++ b/tools/pnpm-workspace.yaml
@@ -1,5 +1,6 @@
 packages:
   - 'skills-api'
+  - 'claudeup-core'
 allowBuilds:
   '@firebase/util': true
   protobufjs: true


### PR DESCRIPTION
## Summary

- `claudeup-core` was removed from `tools/pnpm-workspace.yaml` but the workspace lockfile (`tools/pnpm-lock.yaml`) still declared it as an importer — this mismatch caused `pnpm install` to fail every time CI ran the **Test Plugins** workflow
- Adding `claudeup-core` back to the workspace packages list aligns the definition with the lockfile, which already contains all required dependencies including `vitest` and `@vitest/coverage-v8`

## Root Cause

`tools/pnpm-workspace.yaml` listed only `skills-api`, but `tools/pnpm-lock.yaml` still had a `claudeup-core` importer block. When GitHub Actions ran `pnpm install` from `tools/claudeup-core/` with `CI=true` (which enables `--frozen-lockfile` by default), pnpm detected the lockfile–workspace mismatch and aborted.

Affected runs: 23779059727, 23778999927, 23776816762, 23723312764, 23723077305, 23697252527, 23697213395 (all Test Plugins failures since 2026-03-28).

## Test plan

- [ ] Verify the **Test Plugins** workflow passes on this PR
- [ ] Confirm `pnpm install` in `tools/claudeup-core` installs vitest and all devDeps without error on both Node 20 and 22

https://claude.ai/code/session_014nwGwbkvaV8wvmb7xQmAy9