### PR TITLE
fix(ci): sync kanban marketplace version to 1.1.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -359,7 +359,7 @@
       "name": "kanban",
       "source": "./plugins/kanban",
       "description": "Kanban board view for task management. v1.0.0: Visual board with 5 columns, task dependencies (cycle-safe), priority indicators, WIP limits. Shares tasks.json with GTD plugin \u2014 works standalone or alongside GTD.",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "author": {
         "name": "Jack Rudenko",
         "email": "i@madappgang.com",


### PR DESCRIPTION
## Summary

- `plugins/kanban/plugin.json` was updated to `1.1.0` but `.claude-plugin/marketplace.json` was left at `1.0.0`
- The `marketplace-sync.test.ts` integration test (run as part of `pnpm test:integration`) explicitly checks that every plugin's version in `marketplace.json` matches its `plugin.json`
- This mismatch caused **6 consecutive Test Plugins CI failures** on main

## Root Cause

The `should have version sync between plugin.json and marketplace.json` test in `tools/claudeup-core/src/__tests__/integration/marketplace-sync.test.ts` iterates all marketplace plugins and asserts:

```
pluginJson.version === mpPlugin.version
```

`kanban` failed with:
```
Plugin kanban: version mismatch - plugin.json has 1.1.0, marketplace.json has 1.0.0
```

Since `test:integration` runs ALL integration tests (including `marketplace-sync.test.ts`), this blocked the entire `test` job on both Node 20 and Node 22 matrix entries, and the downstream `marketplace-sync` job never ran.

## Fix

Updated `kanban` entry in `.claude-plugin/marketplace.json`: `"version": "1.0.0"` → `"version": "1.1.0"`

## Test Plan

- [ ] Verify Test Plugins CI passes on this PR
- [ ] Confirm no other version mismatches remain between `plugin.json` files and `marketplace.json`

## Related

- Also investigated 2 NPM Release failures (runs 23782384963 and 23779277073 for claudeup v4.5.2 and v4.5.0) — those are tracked separately in a GitHub issue as they require a human decision on re-tagging.