### PR TITLE
fix(ci): pnpm workspace isolation + kanban version sync

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -359,7 +359,7 @@
       "name": "kanban",
       "source": "./plugins/kanban",
       "description": "Kanban board view for task management. v1.0.0: Visual board with 5 columns, task dependencies (cycle-safe), priority indicators, WIP limits. Shares tasks.json with GTD plugin \u2014 works standalone or alongside GTD.",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "author": {
         "name": "Jack Rudenko",
         "email": "i@madappgang.com",

--- a/.github/workflows/test-plugins.yml
+++ b/.github/workflows/test-plugins.yml
@@ -52,7 +52,7 @@ jobs:
 
       - name: Install dependencies
         working-directory: tools/claudeup-core
-        run: pnpm install
+        run: pnpm install --ignore-workspace
 
       - name: Run type check
         working-directory: tools/claudeup-core
@@ -107,7 +107,7 @@ jobs:
 
       - name: Install dependencies
         working-directory: tools/claudeup-core
-        run: pnpm install
+        run: pnpm install --ignore-workspace
 
       - name: Verify marketplace sync
         working-directory: tools/claudeup-core


### PR DESCRIPTION
## Summary

Two root causes found for the **persistent Test Plugins CI failures since March 28** (10 consecutive failed runs on `main` + the `fix/ci-test-plugins-kanban-version-mismatch` PR also failing):

### 1. pnpm workspace interference (primary — breaks all test runs)

`tools/pnpm-workspace.yaml` exists and only lists `skills-api`. When the CI runs `pnpm install` in `tools/claudeup-core`, pnpm traverses up and finds this workspace config, then installs nothing for `claudeup-core` (since it's not listed as a workspace package). Result: `vitest` is never installed → every single test step fails with `sh: vitest: not found`.

**Fix:** Add `--ignore-workspace` flag to both `pnpm install` steps in `.github/workflows/test-plugins.yml`.

### 2. kanban version mismatch (secondary — caught once CI can actually run)

`plugins/kanban/plugin.json` was bumped to `1.1.0` but `.claude-plugin/marketplace.json` still listed `1.0.0`. The `marketplace-sync` integration test checks all plugin versions match and fails with:
```
Plugin kanban: version mismatch - plugin.json has 1.1.0, marketplace.json has 1.0.0
```

**Fix:** Bump kanban version in `.claude-plugin/marketplace.json` to `1.1.0`.

This also supersedes PR #4 which only fixed the kanban version but couldn't pass CI due to issue #1.

## Test plan

- [x] All 327 tests pass locally (`pnpm install --ignore-workspace && vitest run src/__tests__/unit src/__tests__/integration`)
- [ ] CI passes on this PR

https://claude.ai/code/session_01WchQNzbF6o4DHPttCN3RvA