### PR TITLE
feat: improve skill scores for 5 lowest-scoring skills

### DIFF
--- a/plugins/conductor/skills/help/SKILL.md
+++ b/plugins/conductor/skills/help/SKILL.md
@@ -1,68 +1,45 @@
 ---
 name: help
-description: Get help with Conductor - commands, usage examples, and best practices
+description: "Quick-reference for the Conductor context-driven development CLI — lists all five skills (setup, new-track, implement, status, revert), shows the conductor/ directory layout, and explains the Quick Start workflow with validation checkpoints. Use when the user asks for help with Conductor, wants to list available conductor commands, needs usage examples, or asks how the conductor workflow operates."
 version: 1.0.0
 tags: [conductor, help, documentation, guide]
-keywords: [help, guide, usage, commands, reference]
 user-invocable: false
 ---
-plugin: conductor
-updated: 2026-01-20
 
 # Conductor Help
 
-Conductor implements Context-Driven Development for Claude Code.
-
-## Philosophy
-
-**Context as a Managed Artifact:**
-Your project context (goals, tech stack, workflow) is documented and maintained alongside your code. This context guides all development work.
-
-**Pre-Implementation Planning:**
-Before coding, create a spec (WHAT) and plan (HOW). This ensures clear direction and traceable progress.
-
-**Safe Iteration:**
-Human approval gates at key points. Git-linked commits for traceability. Easy rollback when needed.
+Conductor is a context-driven development system for Claude Code. It stores project context (goals, tech stack, workflow) alongside code, enforces spec-before-code planning, and links every commit to a tracked task.
 
 ## Available Skills
 
 ### conductor:setup
-Initialize Conductor for your project.
-- Creates conductor/ directory structure
-- Generates product.md, tech-stack.md, workflow.md
-- Interactive Q&A with resume capability
+Initialize Conductor for a project. Creates the `conductor/` directory with `product.md`, `tech-stack.md`, `workflow.md`, and code style guides through interactive Q&A. Supports resume if interrupted.
+
+See [setup SKILL](../setup/SKILL.md) for full details.
 
 ### conductor:new-track
-Create a new development track.
-- Generates spec.md with requirements
-- Creates hierarchical plan.md (phases -> tasks)
-- Updates tracks.md index
+Create a development track (feature, bugfix, refactor). Generates `spec.md` (requirements) and `plan.md` (hierarchical phases → tasks → subtasks), then updates `tracks.md`.
+
+See [new-track SKILL](../new-track/SKILL.md) for full details.
 
 ### conductor:implement
-Execute tasks from your plan.
-- Status progression: [ ] -> [~] -> [x]
-- Git commits linked to track/task
-- Follows workflow.md procedures
+Execute tasks from a plan. Progresses status markers: `[ ]` → `[~]` → `[x]`. Each task produces at least one git commit tagged with the track ID. Follows `workflow.md` procedures.
 
 ### conductor:status
-View project progress.
-- Overall completion percentage
-- Current task and blockers
-- Multi-track overview
+Show project progress — overall completion percentage, current task, blockers, and multi-track overview.
 
 ### conductor:revert
-Git-aware logical undo.
-- Revert at Track, Phase, or Task level
-- Preview before executing
-- State validation after revert
+Git-aware logical undo at track, phase, or task level. Previews impact, creates revert commits (preserves history), and validates `plan.md` consistency afterward.
+
+See [revert SKILL](../revert/SKILL.md) for full details.
 
 ## Quick Start
 
-1. **Initialize:** Run `conductor:setup` to create context files
-2. **Plan:** Run `conductor:new-track` to create your first track
-3. **Implement:** Run `conductor:implement` to start working
-4. **Check:** Run `conductor:status` to see progress
-5. **Undo:** Run `conductor:revert` if you need to roll back
+1. **Initialize:** `conductor:setup` → verify `conductor/` directory exists with `product.md`, `tech-stack.md`, `workflow.md`
+2. **Plan:** `conductor:new-track` → verify `conductor/tracks/{track_id}/spec.md` and `plan.md` were created
+3. **Implement:** `conductor:implement` → verify task status in `plan.md` changed to `[x]` and git commit exists
+4. **Check:** `conductor:status` → review completion percentage and blockers
+5. **Undo:** `conductor:revert` → verify reverted tasks show `[ ]` and revert commits exist
 
 ## Directory Structure
 
@@ -81,24 +58,16 @@ conductor/
 
 ## Best Practices
 
-1. **Keep Context Updated:** Review product.md and tech-stack.md periodically
-2. **One Task at a Time:** Focus on completing tasks fully before moving on
-3. **Commit Often:** Each task should result in at least one commit
-4. **Use Blockers:** Mark tasks as [!] blocked rather than skipping silently
+1. **Keep Context Updated:** Review `product.md` and `tech-stack.md` periodically
+2. **One Task at a Time:** Complete tasks fully before moving on
+3. **Commit Often:** Each task should produce at least one commit
+4. **Use Blockers:** Mark tasks as `[!]` blocked rather than skipping silently
 5. **Review Before Proceeding:** Use phase gates to verify quality
 
 ## Troubleshooting
 
-**"Conductor not initialized"**
-Run `conductor:setup` to initialize the conductor/ directory.
-
-**"Track not found"**
-Check tracks.md for available tracks. Track IDs are case-sensitive.
-
-**"Revert failed"**
-Check for uncommitted changes. Commit or stash before reverting.
-
-## Getting Help
-
-Use `conductor:help` anytime for this reference.
-For issues, check the project documentation or file an issue.
+| Error | Fix |
+|-------|-----|
+| "Conductor not initialized" | Run `conductor:setup` to create the `conductor/` directory |
+| "Track not found" | Check `tracks.md` for available tracks — IDs are case-sensitive |
+| "Revert failed" | Commit or stash uncommitted changes before reverting |

--- a/plugins/conductor/skills/new-track/SKILL.md
+++ b/plugins/conductor/skills/new-track/SKILL.md
@@ -1,174 +1,72 @@
 ---
 name: new-track
-description: Create development track with spec and hierarchical plan through interactive Q&A
+description: "Creates a new development track with a requirements spec and hierarchical implementation plan through interactive Q&A. Reads project context from product.md and tech-stack.md to generate actionable phases, tasks, and subtasks. Use when the user asks to plan a new feature, create a bugfix track, start a refactoring effort, or set up a new development workstream."
 version: 1.0.0
 tags: [conductor, track, planning, spec, phases]
-keywords: [new track, feature, bugfix, plan, spec, phases, tasks]
 user-invocable: false
 ---
-plugin: conductor
-updated: 2026-01-20
 
-<role>
-  <identity>Development Planner & Spec Writer</identity>
-  <expertise>
-    - Requirements elicitation and specification
-    - Hierarchical plan creation (phases/tasks/subtasks)
-    - Track lifecycle management
-    - Context-aware planning (reads product.md, tech-stack.md)
-  </expertise>
-  <mission>
-    Transform user requirements into structured, actionable development
-    plans with clear phases, tasks, and subtasks that enable systematic
-    implementation.
-  </mission>
-</role>
+# New Track
 
-<instructions>
-  <critical_constraints>
-    <todowrite_requirement>
-      You MUST use Tasks to track planning progress:
-      1. Validate conductor setup exists
-      2. Gather track requirements
-      3. Generate track ID
-      4. Create spec.md
-      5. Create plan.md with phases
-      6. Create metadata.json
-      7. Update tracks.md index
-    </todowrite_requirement>
+Create a structured development track by gathering requirements through interactive Q&A, then generating a spec and hierarchical plan.
 
-    <conductor_required>
-      FIRST check if conductor/ directory exists with required files.
-      If not, HALT and guide user to run conductor:setup first.
-    </conductor_required>
+## Prerequisites
 
-    <context_awareness>
-      ALWAYS read these files before planning:
-      - conductor/product.md (understand project goals)
-      - conductor/tech-stack.md (know technical constraints)
-      - conductor/workflow.md (follow team processes)
-    </context_awareness>
+Before starting, verify `conductor/` directory exists with required files: `product.md`, `tech-stack.md`, `workflow.md`. If missing, halt and guide the user to run `conductor:setup` first.
 
-    <track_id_format>
-      Format: {shortname}_{YYYYMMDD}
-      Examples:
-      - feature_auth_20260105
-      - bugfix_login_20260105
-      - refactor_api_20260105
-    </track_id_format>
-  </critical_constraints>
+## Context Loading
 
-  <core_principles>
-    <principle name="Spec Before Plan" priority="critical">
-      Always create spec.md BEFORE plan.md.
-      Spec defines WHAT, Plan defines HOW.
-    </principle>
+Always read before planning:
+- `conductor/product.md` — project goals
+- `conductor/tech-stack.md` — technical constraints
+- `conductor/tracks.md` — existing tracks
 
-    <principle name="Hierarchical Plans" priority="critical">
-      Plans must have:
-      - 2-6 Phases (major milestones)
-      - 2-5 Tasks per phase
-      - 0-3 Subtasks per task (optional)
-    </principle>
+## Workflow
 
-    <principle name="Actionable Tasks" priority="high">
-      Each task must be:
-      - Specific (clear outcome)
-      - Estimable (roughly 1-4 hours)
-      - Independent (minimal dependencies)
-    </principle>
-  </core_principles>
+### Phase 1: Track Type
 
-  <workflow>
-    <phase number="1" name="Validation">
-      <step>Check conductor/ directory exists</step>
-      <step>Check required files: product.md, tech-stack.md, workflow.md</step>
-      <step>If missing, HALT with guidance to run setup</step>
-      <step>Initialize Tasks</step>
-    </phase>
+1. Ask: What type of work? (Feature, Bugfix, Refactor, Task)
+2. Ask: Short name for this track? (3-10 chars, lowercase)
+3. Generate track ID: `{type}_{shortname}_{YYYYMMDD}` (e.g. `feature_auth_20260105`)
 
-    <phase number="2" name="Context Loading">
-      <step>Read conductor/product.md</step>
-      <step>Read conductor/tech-stack.md</step>
-      <step>Read conductor/tracks.md for existing tracks</step>
-    </phase>
+### Phase 2: Spec Generation
 
-    <phase number="3" name="Track Type">
-      <step>Ask: What type of work? [Feature, Bugfix, Refactor, Task, Other]</step>
-      <step>Ask: Short name for this track? (3-10 chars, lowercase)</step>
-      <step>Generate track ID: {type}_{shortname}_{YYYYMMDD}</step>
-    </phase>
+1. Ask: What is the goal? (1-2 sentences)
+2. Ask: Acceptance criteria? (3-5 items)
+3. Ask: Technical constraints or dependencies?
+4. Ask: Edge cases or error scenarios?
+5. Generate `conductor/tracks/{track_id}/spec.md`
 
-    <phase number="4" name="Spec Generation">
-      <step>Ask: What is the goal of this work? (1-2 sentences)</step>
-      <step>Ask: What are the acceptance criteria? (list 3-5)</step>
-      <step>Ask: Any technical constraints or dependencies?</step>
-      <step>Ask: Any edge cases or error scenarios to handle?</step>
-      <step>Generate conductor/tracks/{track_id}/spec.md</step>
-    </phase>
+### Phase 3: Plan Generation
 
-    <phase number="5" name="Plan Generation">
-      <step>Based on spec, propose 2-6 phases</step>
-      <step>Ask user to confirm or modify phases</step>
-      <step>For each phase, generate 2-5 tasks</step>
-      <step>Add subtasks where complexity warrants</step>
-      <step>Generate conductor/tracks/{track_id}/plan.md</step>
-    </phase>
+1. Based on spec, propose 2-6 phases
+2. Ask user to confirm or modify phases
+3. For each phase, generate 2-5 tasks with optional subtasks (0-3 per task)
+4. Generate `conductor/tracks/{track_id}/plan.md`
 
-    <phase number="6" name="Finalization">
-      <step>Create conductor/tracks/{track_id}/metadata.json</step>
-      <step>Update conductor/tracks.md with new track</step>
-      <step>Present summary to user</step>
-    </phase>
-  </workflow>
-</instructions>
+### Phase 4: Finalization
 
-<knowledge>
-  <track_types>
-    **Feature:** New functionality
-    - Larger scope, 4-6 phases typical
-    - Includes testing and documentation phases
+1. Create `conductor/tracks/{track_id}/metadata.json`
+2. Update `conductor/tracks.md` with the new track
+3. Present completion summary
 
-    **Bugfix:** Fix existing issue
-    - Smaller scope, 2-3 phases typical
-    - Includes reproduction and verification phases
+## Core Principles
 
-    **Refactor:** Code improvement
-    - Medium scope, 3-4 phases typical
-    - Includes before/after comparison phase
+- **Spec before plan**: Create spec.md first (defines WHAT), then plan.md (defines HOW)
+- **Hierarchical plans**: 2-6 phases, 2-5 tasks per phase, 0-3 subtasks per task
+- **Actionable tasks**: Each task must be specific (clear outcome), estimable (1-4 hours), and independent (minimal dependencies)
 
-    **Task:** General work item
-    - Variable scope
-    - Flexible structure
-  </track_types>
+## Track Types
 
-  <plan_structure>
-```markdown
-# Plan: {Track Title}
+| Type | Scope | Typical Phases | Notes |
+|------|-------|----------------|-------|
+| Feature | Large | 4-6 | Includes testing and documentation phases |
+| Bugfix | Small | 2-3 | Includes reproduction and verification phases |
+| Refactor | Medium | 3-4 | Includes before/after comparison phase |
+| Task | Variable | Flexible | General work item |
 
-Track ID: {track_id}
-Type: {Feature/Bugfix/Refactor/Task}
-Created: {YYYY-MM-DD}
-Status: Active
+## Spec Template
 
-## Phase 1: {Phase Name}
-- [ ] 1.1 {Task description}
-- [ ] 1.2 {Task description}
-  - [ ] 1.2.1 {Subtask}
-  - [ ] 1.2.2 {Subtask}
-- [ ] 1.3 {Task description}
-
-## Phase 2: {Phase Name}
-- [ ] 2.1 {Task description}
-- [ ] 2.2 {Task description}
-
-## Phase 3: Testing & Documentation
-- [ ] 3.1 Write unit tests
-- [ ] 3.2 Update documentation
-```
-  </plan_structure>
-
-  <spec_template>
 ```markdown
 # Spec: {Track Title}
 
@@ -188,54 +86,54 @@ Created: {YYYY-MM-DD}
 - [ ] {Criterion 3}
 
 ## Technical Constraints
-- {Constraint 1 from tech-stack.md}
-- {Constraint 2}
+- {Constraint from tech-stack.md}
 
 ## Edge Cases
 - {Edge case 1}
-- {Edge case 2}
 
 ## Out of Scope
 - {What this track does NOT include}
 ```
-  </spec_template>
-</knowledge>
 
-<examples>
-  <example name="New Feature Track">
-    <user_request>I want to add user authentication</user_request>
-    <correct_approach>
-      1. Validate conductor/ exists with required files
-      2. Load product.md, tech-stack.md context
-      3. Ask track type - "Feature"
-      4. Ask short name - "auth"
-      5. Generate ID: feature_auth_20260105
-      6. Ask spec questions (goal, criteria, constraints)
-      7. Generate spec.md
-      8. Propose phases: Database, Core Auth, Sessions, Testing
-      9. User confirms phases
-      10. Generate plan.md with tasks
-      11. Update tracks.md index
-    </correct_approach>
-  </example>
+## Plan Template
 
-  <example name="Bugfix Track">
-    <user_request>Login page keeps redirecting in a loop</user_request>
-    <correct_approach>
-      1. Validate conductor/ exists
-      2. Load context
-      3. Track type: "Bugfix"
-      4. Short name: "login-loop"
-      5. Generate ID: bugfix_login-loop_20260105
-      6. Spec: Reproduce, root cause, fix approach
-      7. Plan phases: Reproduce (1), Fix (2), Verify (3)
-      8. Generate files and update index
-    </correct_approach>
-  </example>
-</examples>
+```markdown
+# Plan: {Track Title}
 
-<formatting>
-  <completion_template>
+Track ID: {track_id}
+Type: {Feature/Bugfix/Refactor/Task}
+Created: {YYYY-MM-DD}
+Status: Active
+
+## Phase 1: {Phase Name}
+- [ ] 1.1 {Task description}
+- [ ] 1.2 {Task description}
+  - [ ] 1.2.1 {Subtask}
+  - [ ] 1.2.2 {Subtask}
+- [ ] 1.3 {Task description}
+
+## Phase 2: {Phase Name}
+- [ ] 2.1 {Task description}
+- [ ] 2.2 {Task description}
+```
+
+## Examples
+
+**Feature track** — User says "I want to add user authentication":
+1. Track type: Feature, short name: "auth", ID: `feature_auth_20260105`
+2. Gather spec (goal, criteria, constraints) → generate spec.md
+3. Propose phases: Database, Core Auth, Sessions, Testing → generate plan.md
+4. Update tracks.md index
+
+**Bugfix track** — User says "Login page keeps redirecting in a loop":
+1. Track type: Bugfix, short name: "login-loop", ID: `bugfix_login-loop_20260105`
+2. Spec: reproduction steps, root cause, fix approach
+3. Plan phases: Reproduce → Fix → Verify
+4. Generate files and update index
+
+## Completion Template
+
+```
 ## Track Created Successfully
 
 **Track ID:** {track_id}
@@ -249,12 +147,10 @@ Created: {YYYY-MM-DD}
 **Plan Summary:**
 - Phase 1: {name} ({N} tasks)
 - Phase 2: {name} ({N} tasks)
-- Phase 3: {name} ({N} tasks)
 - Total: {X} phases, {Y} tasks
 
 **Next Steps:**
 1. Review spec.md and plan.md
 2. Adjust if needed
 3. Run `conductor:implement` to start executing
-  </completion_template>
-</formatting>
+```

--- a/plugins/conductor/skills/revert/SKILL.md
+++ b/plugins/conductor/skills/revert/SKILL.md
@@ -1,228 +1,109 @@
 ---
 name: revert
-description: Git-aware logical undo at track, phase, or task level with confirmation gates
+description: "Performs git-aware logical undo of development work at track, phase, or task granularity with impact preview and confirmation gates. Creates revert commits while preserving history, then validates plan.md consistency. Use when the user asks to undo, roll back, or revert completed work from a Conductor track, phase, or task."
 version: 1.0.0
 tags: [conductor, revert, undo, git, rollback]
-keywords: [revert, undo, rollback, git, track, phase, task]
 user-invocable: false
 ---
-plugin: conductor
-updated: 2026-01-20
 
-<role>
-  <identity>Safe Revert Specialist</identity>
-  <expertise>
-    - Git history analysis and reversal
-    - Logical grouping of commits by track/phase/task
-    - State validation after reversal
-    - Safe rollback with confirmation gates
-  </expertise>
-  <mission>
-    Enable safe, logical rollback of development work at meaningful
-    granularity (track/phase/task) while maintaining git history integrity
-    and project consistency.
-  </mission>
-</role>
+## Workflow
 
-<instructions>
-  <critical_constraints>
-    <todowrite_requirement>
-      You MUST use Tasks to track the revert workflow.
+Track the revert using these 5 phases. Mark each "in_progress" when starting, "completed" when done. Only one phase active at a time.
 
-      **Before starting**, create todo list with these 5 phases:
-      1. Scope Selection - Identify what to revert (track/phase/task)
-      2. Impact Analysis - Find commits, files, status changes
-      3. User Confirmation - Present impact and get approval
-      4. Execution - Create revert commits and update files
-      5. Validation - Verify consistency and report results
+### Phase 1 — Scope Selection
 
-      **Update continuously**:
-      - Mark "in_progress" when starting each phase
-      - Mark "completed" immediately after finishing
-      - Keep only ONE phase "in_progress" at a time
-    </todowrite_requirement>
+- Ask what to revert: Track, Phase, or Task
+- Narrow down: which track, which phase, or which task
 
-    <confirmation_required>
-      ALWAYS require explicit user confirmation before:
-      - Reverting any commits
-      - Modifying plan.md status
-      - Deleting track files
+### Phase 2 — Impact Analysis
 
-      Show exactly what will be changed BEFORE doing it.
-    </confirmation_required>
+- Read metadata.json to find related commits
+- List all commits, affected files, and plan.md status changes
 
-    <non_destructive_default>
-      Default to creating revert commits, not force-pushing.
-      Preserve git history unless user explicitly requests otherwise.
-    </non_destructive_default>
+### Phase 3 — User Confirmation
 
-    <state_validation>
-      After any revert:
-      1. Verify plan.md matches git state
-      2. Verify metadata.json is consistent
-      3. Run project quality checks
-      4. Report any inconsistencies
-    </state_validation>
-  </critical_constraints>
+- Present the impact preview (see template below)
+- Require explicit approval before proceeding
+- If declined, abort with no changes
 
-  <core_principles>
-    <principle name="Logical Grouping" priority="critical">
-      Revert by logical units (track/phase/task), not raw commits.
-      A task might have multiple commits - revert them together.
-    </principle>
+### Phase 4 — Execution
 
-    <principle name="Preview Before Action" priority="critical">
-      Show user exactly what will be reverted before doing it.
-      List commits, files, status changes.
-    </principle>
+- Create revert commits for each original commit
+- Update plan.md statuses back to `[ ]`
+- Update metadata.json to reflect the revert
 
-    <principle name="Graceful Degradation" priority="high">
-      If full revert fails, offer partial revert options.
-      Never leave project in inconsistent state.
-    </principle>
-  </core_principles>
+### Phase 5 — Validation
 
-  <workflow>
-    <phase number="1" name="Scope Selection">
-      <step>Ask: What to revert? [Track, Phase, Task]</step>
-      <step>If Track: Ask which track</step>
-      <step>If Phase: Ask which track, which phase</step>
-      <step>If Task: Ask which track, which task</step>
-    </phase>
+- Verify plan.md matches git state
+- Verify metadata.json is consistent
+- Run project quality checks and report results
 
-    <phase number="2" name="Impact Analysis">
-      <step>Read metadata.json to find related commits</step>
-      <step>List all commits that will be reverted</step>
-      <step>List all files that will be affected</step>
-      <step>List status changes in plan.md</step>
-    </phase>
+## Critical Constraints
 
-    <phase number="3" name="User Confirmation">
-      <step>Present impact analysis to user</step>
-      <step>Ask for explicit confirmation</step>
-      <step>If declined, abort with no changes</step>
-    </phase>
+- **Confirmation required**: Always get explicit user confirmation before reverting commits, modifying plan.md, or deleting track files. Show exactly what will change first.
+- **Non-destructive default**: Create revert commits, not force pushes. Preserve git history unless the user explicitly requests otherwise.
+- **Graceful degradation**: If full revert fails, offer partial revert options. Never leave the project in an inconsistent state.
+- **Logical grouping**: Revert by logical units (track/phase/task), not raw commits. A task may have multiple commits — revert them together.
 
-    <phase number="4" name="Execution">
-      <step>Create revert commits for each original commit</step>
-      <step>Update plan.md statuses back to [ ]</step>
-      <step>Update metadata.json to reflect revert</step>
-      <step>Remove completed tasks from history</step>
-    </phase>
+## Revert Levels
 
-    <phase number="5" name="Validation">
-      <step>Verify git state matches plan.md</step>
-      <step>Run project quality checks</step>
-      <step>Report final state to user</step>
-    </phase>
-  </workflow>
-</instructions>
+**Task** — Reverts a single task's commits. Updates that task to `[ ]`. Preserves other tasks in the phase.
 
-<knowledge>
-  <revert_levels>
-    **Task Level:**
-    - Reverts single task's commits
-    - Updates task status to [ ]
-    - Preserves other tasks in phase
+**Phase** — Reverts all tasks in a phase. Resets all their statuses to `[ ]`. Preserves other phases.
 
-    **Phase Level:**
-    - Reverts all tasks in phase
-    - Updates all task statuses to [ ]
-    - Preserves other phases
+**Track** — Reverts the entire track. Optionally deletes track files. Updates tracks.md index.
 
-    **Track Level:**
-    - Reverts entire track
-    - Optionally deletes track files
-    - Updates tracks.md index
-  </revert_levels>
+## Commit Identification
 
-  <commit_identification>
-    Find commits for a task using:
-    1. metadata.json commit array
-    2. Git log searching for "[{track_id}]" pattern
-    3. Git notes with task references
-  </commit_identification>
+Find commits for a task using:
+1. `metadata.json` commit array
+2. Git log searching for `[{track_id}]` pattern
+3. Git notes with task references
 
-  <revert_strategies>
-    **Safe Revert (Default):**
-    - Create revert commits
-    - Preserves full history
-    - Can be undone
+## Revert Strategies
 
-    **Hard Reset (Requires explicit request):**
-    - Reset branch to before commits
-    - Loses history (unless pushed)
-    - Cannot be easily undone
-  </revert_strategies>
-</knowledge>
+**Safe revert (default)** — Creates revert commits. Preserves full history. Can be undone.
 
-<examples>
-  <example name="Revert Single Task">
-    <user_request>Undo task 2.3</user_request>
-    <correct_approach>
-      1. Identify track with task 2.3
-      2. Find commits for task 2.3 from metadata.json
-      3. Show impact:
-         "Will revert 2 commits:
-          - abc123: [feature_auth] Implement login form
-          - def456: [feature_auth] Add login validation
-          Files affected: src/login.tsx, src/auth.ts"
-      4. Ask confirmation
-      5. Create revert commits
-      6. Update plan.md: 2.3 [x] -> [ ]
-      7. Update metadata.json
-      8. Validate state
-    </correct_approach>
-  </example>
+**Hard reset (requires explicit request)** — Resets branch to before commits. Loses history unless pushed. Cannot be easily undone.
 
-  <example name="Revert Entire Phase">
-    <user_request>Roll back Phase 2 of the auth feature</user_request>
-    <correct_approach>
-      1. Find all tasks in Phase 2
-      2. Find all commits for those tasks
-      3. Show impact:
-         "Will revert 8 commits affecting Phase 2 (5 tasks):
-          - 2.1 Implement password hashing (2 commits)
-          - 2.2 Create login endpoint (3 commits)
-          - 2.3 Create registration endpoint (3 commits)
-          Files affected: 12 files"
-      4. Ask confirmation: "This will undo significant work. Proceed?"
-      5. Create revert commits in reverse order
-      6. Update all Phase 2 task statuses to [ ]
-      7. Update metadata.json
-      8. Validate state
-    </correct_approach>
-  </example>
-</examples>
+## Examples
 
-<formatting>
-  <impact_preview_template>
+**Revert single task** — User says "Undo task 2.3":
+1. Identify the track containing task 2.3
+2. Find commits from metadata.json
+3. Show impact: "Will revert 2 commits: abc123 Implement login form, def456 Add login validation. Files: src/login.tsx, src/auth.ts"
+4. Get confirmation, create revert commits
+5. Update plan.md (2.3 `[x]` → `[ ]`) and metadata.json, then validate
+
+**Revert entire phase** — User says "Roll back Phase 2 of auth feature":
+1. Find all Phase 2 tasks and their commits
+2. Show impact: "Will revert 8 commits across 5 tasks affecting 12 files"
+3. Get confirmation, create revert commits in reverse order
+4. Reset all Phase 2 statuses to `[ ]`, update metadata.json, validate
+
+## Impact Preview Template
+
+```
 ## Revert Impact Analysis
 
 **Scope:** {Task/Phase/Track} {identifier}
-
 **Commits to Revert:** {N}
-{#each commit}
 - {short_sha}: {message}
-{/each}
 
 **Files Affected:** {N}
-{#each file}
 - {filepath}
-{/each}
 
 **Status Changes in plan.md:**
-{#each task}
 - {task_id}: [x] -> [ ]
-{/each}
 
-**WARNING:** This action will create {N} revert commits.
-Git history will be preserved.
+**WARNING:** This will create {N} revert commits. Git history will be preserved.
 
 Proceed with revert? [Yes/No]
-  </impact_preview_template>
+```
 
-  <completion_template>
+## Completion Template
+
+```
 ## Revert Complete
 
 **Reverted:** {scope} {identifier}
@@ -233,7 +114,4 @@ Proceed with revert? [Yes/No]
 - Plan.md: Consistent
 - Git State: Clean
 - Quality Checks: PASS
-
-The {scope} has been reverted. You can re-implement or abandon this work.
-  </completion_template>
-</formatting>
+```

--- a/plugins/conductor/skills/setup/SKILL.md
+++ b/plugins/conductor/skills/setup/SKILL.md
@@ -1,171 +1,141 @@
 ---
 name: setup
-description: Initialize Conductor with product.md, tech-stack.md, and workflow.md
+description: "Initializes the Conductor project orchestration system by guiding the user through interactive Q&A to create product.md, tech-stack.md, workflow.md, and code style guides. Use when the user asks to set up Conductor, initialize a new project workspace, bootstrap project configuration, or start a new development environment."
 version: 1.1.0
 tags: [conductor, setup, initialization, context, project]
-keywords: [conductor setup, initialize, project context, greenfield, brownfield]
 user-invocable: false
 ---
-plugin: conductor
-updated: 2026-01-20
 
-<role>
-  <identity>Project Context Architect</identity>
-  <expertise>
-    - Project initialization and context gathering
-    - Interactive Q&A for requirements elicitation
-    - State management and resume capability
-    - Greenfield vs Brownfield project handling
-  </expertise>
-  <mission>
-    Guide users through structured project initialization, creating
-    comprehensive context artifacts that serve as the foundation for
-    all future development work.
-  </mission>
-</role>
+## Critical Constraints
 
-<instructions>
-  <critical_constraints>
-    <todowrite_requirement>
-      You MUST use Tasks to track setup progress:
-      1. Check for existing conductor/ directory
-      2. Determine project type (Greenfield/Brownfield)
-      3. Create product.md through Q&A
-      4. Create product-guidelines.md
-      5. Create tech-stack.md through Q&A
-      6. Create code styleguides
-      7. Copy workflow.md template
-      8. Finalize setup
-    </todowrite_requirement>
+- **Task tracking**: Use Tasks to track setup progress through all phases
+- **Sequential questions**: Ask one question at a time; wait for the answer before continuing
+- **Maximum 5 questions per section**; always include a "Type your own answer" option
+- **Save state after each answer** to `conductor/setup_state.json` for resume capability
 
-    <resume_capability>
-      Check for conductor/setup_state.json FIRST.
-      If exists with status != "complete":
-      1. Load saved answers
-      2. Resume from last incomplete section
-      3. Show user what was already collected
-    </resume_capability>
+### Resume Capability
 
-    <question_protocol>
-      - Ask questions SEQUENTIALLY (one at a time)
-      - Maximum 5 questions per section
-      - Always include "Type your own answer" option
-      - Use AskUserQuestion with appropriate question types
-      - Save state after EACH answer (for resume)
-    </question_protocol>
+Check for `conductor/setup_state.json` **before starting**. If it exists with `status != "complete"`:
 
-    <validation_first>
-      Before any operation:
-      1. Check if conductor/ already exists
-      2. If complete setup exists, ask: "Re-initialize or abort?"
-      3. Respect .gitignore patterns
-    </validation_first>
-  </critical_constraints>
+1. Load saved answers
+2. Resume from last incomplete section
+3. Show user what was already collected
 
-  <core_principles>
-    <principle name="Single Question Flow" priority="critical">
-      Never ask multiple questions at once.
-      Wait for answer before asking next question.
-    </principle>
+### Pre-flight Validation
 
-    <principle name="State Persistence" priority="critical">
-      Save progress after each answer.
-      Enable resume from any interruption point.
-    </principle>
+1. Check if `conductor/` directory already exists
+2. If a complete setup exists, ask: "Re-initialize or abort?"
+3. Respect `.gitignore` patterns
 
-    <principle name="Context Quality" priority="high">
-      Gather enough context to be useful.
-      Don't overwhelm with excessive questions.
-    </principle>
-  </core_principles>
+## Workflow
 
-  <workflow>
-    <phase number="1" name="Validation">
-      <step>Check if conductor/ directory exists</step>
-      <step>If exists, check setup_state.json for resume</step>
-      <step>If complete setup exists, confirm re-initialization</step>
-      <step>Initialize Tasks with setup phases</step>
-    </phase>
+### Phase 1: Validation
 
-    <phase number="2" name="Project Type Detection">
-      <step>Check for existing code files (src/, package.json, etc.)</step>
-      <step>Ask user: Greenfield (new) or Brownfield (existing)?</step>
-      <step>For Brownfield: Scan existing code for context</step>
-    </phase>
+1. Check if `conductor/` directory exists
+2. If exists, check `setup_state.json` for resume
+3. If complete setup exists, confirm re-initialization
+4. Initialize Tasks with setup phases
 
-    <phase number="3" name="Product Context">
-      <step>Ask: What is this project about? (1-2 sentences)</step>
-      <step>Ask: Who is the target audience?</step>
-      <step>Ask: What are the 3 main goals?</step>
-      <step>Ask: Any constraints or requirements?</step>
-      <step>Generate product.md from answers</step>
-    </phase>
+### Phase 2: Project Type Detection
 
-    <phase number="4" name="Technical Context">
-      <step>Ask: Primary programming language(s)?</step>
-      <step>Ask: Key frameworks/libraries?</step>
-      <step>Ask: Database/storage preferences?</step>
-      <step>Ask: Deployment target?</step>
-      <step>Generate tech-stack.md from answers</step>
-    </phase>
+1. Check for existing code files (`src/`, `package.json`, etc.)
+2. Ask user: new project or existing codebase?
+3. For existing projects: scan existing code for context
 
-    <phase number="5" name="Guidelines">
-      <step>Ask: Any specific coding conventions?</step>
-      <step>Ask: Testing requirements?</step>
-      <step>Generate product-guidelines.md</step>
-      <step>Generate code_styleguides/general.md (always)</step>
-      <step>Generate language-specific styleguides based on tech stack:
-        - TypeScript/JavaScript → typescript.md, javascript.md
-        - Web projects → html-css.md
-        - Python → python.md
-        - Go → go.md
-      </step>
-    </phase>
+### Phase 3: Product Context
 
-    <phase number="6" name="Finalization">
-      <step>Copy workflow.md template</step>
-      <step>Create empty tracks.md</step>
-      <step>Mark setup_state.json as complete</step>
-      <step>Present summary to user</step>
-    </phase>
-  </workflow>
-</instructions>
+1. Ask: What is this project about? (1-2 sentences)
+2. Ask: Who is the target audience?
+3. Ask: What are the 3 main goals?
+4. Ask: Any constraints or requirements?
+5. Generate `conductor/product.md` from answers
 
-<knowledge>
-  <greenfield_vs_brownfield>
-    **Greenfield (New Project):**
-    - No existing code to analyze
-    - More questions needed about vision
-    - Focus on future architecture
+### Phase 4: Technical Context
 
-    **Brownfield (Existing Project):**
-    - Scan existing files for context
-    - Infer tech stack from package.json, requirements.txt, etc.
-    - Focus on documenting current state
-  </greenfield_vs_brownfield>
+1. Ask: Primary programming language(s)?
+2. Ask: Key frameworks/libraries?
+3. Ask: Database/storage preferences?
+4. Ask: Deployment target?
+5. Generate `conductor/tech-stack.md` from answers
 
-  <question_types>
-    **Additive (Multi-Select):**
-    - "Which frameworks are you using?" [React, Vue, Angular, Other]
-    - User can select multiple
+### Phase 5: Guidelines
 
-    **Exclusive (Single-Select):**
-    - "Primary language?" [TypeScript, Python, Go, Other]
-    - User picks one
+1. Ask: Any specific coding conventions?
+2. Ask: Testing requirements?
+3. Generate `conductor/product-guidelines.md`
+4. Generate `conductor/code_styleguides/general.md` (always)
+5. Generate language-specific styleguides based on tech stack:
+   - TypeScript/JavaScript: `typescript.md`, `javascript.md`
+   - Web projects: `html-css.md`
+   - Python: `python.md`
+   - Go: `go.md`
 
-    **Open-Ended:**
-    - "Describe your project in 1-2 sentences"
-    - Free text response
-  </question_types>
+### Phase 6: Finalization
 
-  <state_file_schema>
+1. Copy `workflow.md` template
+2. Create empty `tracks.md`
+3. Mark `setup_state.json` as complete
+4. Present summary to user
+
+## Artifact Validation
+
+After generating each artifact, verify it contains the required sections:
+
+- **product.md**: Must include `## Overview`, `## Target Audience`, `## Goals`, `## Constraints`
+- **tech-stack.md**: Must include `## Languages`, `## Frameworks`, `## Storage`, `## Deployment`
+- **product-guidelines.md**: Must include `## Coding Conventions`, `## Testing Requirements`
+
+If any section is missing, re-prompt the user for the missing information before writing the file.
+
+## Artifact Templates
+
+### product.md
+
+```markdown
+# {Project Name}
+
+## Overview
+{1-2 sentence description from user}
+
+## Target Audience
+{audience answer}
+
+## Goals
+1. {goal 1}
+2. {goal 2}
+3. {goal 3}
+
+## Constraints
+{constraints or "None specified"}
+```
+
+### tech-stack.md
+
+```markdown
+# Tech Stack
+
+## Languages
+- {primary language}
+
+## Frameworks
+- {framework list}
+
+## Storage
+- {database/storage choice or "TBD"}
+
+## Deployment
+- {deployment target or "TBD"}
+```
+
+## State File Schema
+
 ```json
 {
-  "status": "in_progress" | "complete",
+  "status": "in_progress | complete",
   "startedAt": "ISO-8601",
   "lastUpdated": "ISO-8601",
-  "projectType": "greenfield" | "brownfield",
-  "currentSection": "product" | "tech" | "guidelines",
+  "projectType": "greenfield | brownfield",
+  "currentSection": "product | tech | guidelines",
   "answers": {
     "product": {
       "description": "...",
@@ -179,44 +149,30 @@ updated: 2026-01-20
   }
 }
 ```
-  </state_file_schema>
-</knowledge>
 
-<examples>
-  <example name="New Project Setup">
-    <user_request>I want to set up Conductor for my new project</user_request>
-    <correct_approach>
-      1. Check for existing conductor/ - not found
-      2. Ask: "Is this a new project (Greenfield) or existing codebase (Brownfield)?"
-      3. User: "New project"
-      4. Begin product context questions (one at a time)
-      5. Save each answer to setup_state.json
-      6. After all sections, generate artifacts
-      7. Present summary with next steps
-    </correct_approach>
-  </example>
+## Examples
 
-  <example name="Resume Interrupted Setup">
-    <user_request>Continue setting up Conductor</user_request>
-    <correct_approach>
-      1. Check conductor/setup_state.json - found, status: "in_progress"
-      2. Load previous answers from state
-      3. Show: "Resuming setup. You've completed: Product Context"
-      4. Continue from Technical Context section
-      5. Complete remaining sections
-    </correct_approach>
-  </example>
-</examples>
+**New Project Setup**: User says "I want to set up Conductor for my new project"
 
-<formatting>
-  <communication_style>
-    - Friendly, guiding tone
-    - Clear progress indicators
-    - Explain why each question matters
-    - Confirm understanding before proceeding
-  </communication_style>
+1. Check for existing `conductor/` — not found
+2. Ask: "Is this a new project or an existing codebase?"
+3. User: "New project"
+4. Begin product context questions (one at a time)
+5. Save each answer to `setup_state.json`
+6. After all sections, generate artifacts and validate required sections
+7. Present summary with next steps
 
-  <completion_template>
+**Resume Interrupted Setup**: User says "Continue setting up Conductor"
+
+1. Check `conductor/setup_state.json` — found, status: `in_progress`
+2. Load previous answers from state
+3. Show: "Resuming setup. You've completed: Product Context"
+4. Continue from Technical Context section
+5. Complete remaining sections
+
+## Completion Template
+
+```
 ## Conductor Setup Complete
 
 **Project:** {project_name}
@@ -226,7 +182,7 @@ updated: 2026-01-20
 - conductor/product.md - Project vision and goals
 - conductor/product-guidelines.md - Standards and conventions
 - conductor/tech-stack.md - Technical preferences
-- conductor/workflow.md - Development workflow (comprehensive)
+- conductor/workflow.md - Development workflow
 - conductor/tracks.md - Track index (empty)
 - conductor/code_styleguides/general.md - General coding principles
 - conductor/code_styleguides/{language}.md - Language-specific guides
@@ -235,7 +191,4 @@ updated: 2026-01-20
 1. Review generated artifacts and adjust as needed
 2. Use `conductor:new-track` to plan your first feature
 3. Use `conductor:implement` to execute the plan
-
-Your project is now ready for Context-Driven Development!
-  </completion_template>
-</formatting>
+```

--- a/plugins/dev/skills/planning/brainstorming/SKILL.md
+++ b/plugins/dev/skills/planning/brainstorming/SKILL.md
@@ -1,82 +1,23 @@
 ---
 name: brainstorming
 version: 2.0.0
-description: "Collaborative ideation and planning with resilient multi-model exploration, consensus scoring, and adaptive confidence-based validation"
+description: "Brainstorms implementation approaches by running parallel multi-model exploration, scoring consensus across proposals, and producing a validated plan. Use when the user asks to brainstorm ideas, compare approaches, plan architecture, or evaluate options for a feature before implementing."
 author: "Magus"
 tags:
   - planning
   - ideation
   - collaboration
   - multi-model
-  - resilient
-dependencies:
-  skills:
-    - superpowers:using-git-worktrees
-    - superpowers:writing-plans
-  tools:
-    - Task
-    - TaskCreate
-    - TaskUpdate
-    - TaskList
-    - TaskGet
-    - Read
-    - Write
-    - Edit
-    - Glob
-  models:
-    # Read shared/model-aliases.json for current model IDs. Run /update-models to refresh.
-    primary:
-      - internal  # Claude (embedded)
-    explorers:
-      # Use models from shared/model-aliases.json → teams.code or teams.review
-      fallback_chain:
-        - (models from shared/model-aliases.json teams.code)
-parameters:
-  exploration_models: 3
-  chunk_size: 250
-  confidence_threshold_auto: 95
-  confidence_threshold_confirm: 60
-  retry_attempts: 2
-  timeout_per_model_ms: 120000
-gates:
-  - phase: 0
-    type: USER_GATE
-    trigger: "Problem understanding validated"
-  - phase: 1
-    type: AUTO_GATE
-    trigger: "Parallel exploration consolidated"
-  - phase: 2
-    type: AUTO_GATE
-    trigger: "Consensus scores calculated"
-  - phase: 3
-    type: USER_GATE
-    trigger: "User selects approach"
-  - phase: 4
-    type: MIXED_GATE
-    trigger: "Section-by-section validation"
-  - phase: 5
-    type: USER_GATE
-    trigger: "Final plan approval"
 user-invocable: false
 ---
 
-# Brainstorming v2.0: Resilient Multi-Model Planning
+# Brainstorming: Multi-Model Planning
 
-Turn ideas into validated designs through collaborative AI dialogue with resilient model execution and confidence-based validation.
-
-## Overview
-
-This skill improves upon v1.0 by addressing critical reliability gaps:
-
-**Key v2.0 Improvements:**
-- **No AskUserQuestion dependency**: Uses Task + Tasks for structured interaction
-- **Fallback chains**: 3+ models per role ensures completion even if some fail
-- **Explicit parallelism**: Documented Task call patterns for parallel execution
-- **Defined algorithms**: Consensus matrix and confidence scoring are mathematically specified
+Turn ideas into validated designs through collaborative AI exploration and confidence-based validation.
 
 ## When to Use
 
-Use this skill BEFORE implementing any feature:
+Activate this skill BEFORE implementing any feature:
 - "Design a user authentication system"
 - "Brainstorm approaches for API rate limiting"
 - "Plan architecture for a new dashboard feature"
@@ -84,480 +25,106 @@ Use this skill BEFORE implementing any feature:
 
 ## Prerequisites
 
-### Required Setup
-
-```bash
-# 1. Install required skills
-/plugin marketplace add MadAppGang/magus
-skill install superpowers:using-git-worktrees
-skill install superpowers:writing-plans
-
-# 2. Verify OpenRouter access (for multi-model)
-export OPENROUTER_API_KEY=your-key
-
-# 3. Configure models in ~/.claude/settings.json
-# Use model IDs from shared/model-aliases.json (run /update-models to refresh)
-{
-  "brainstorming": {
-    "primary_model": "internal",
-    "explorer_models": [
-      "(model alias from shared/model-aliases.json shortAliases or teams.code)"
-    ]
-  }
-}
-```
-
-### Model Requirements
-
-| Role | Min Context | Capabilities |
-|------|-------------|--------------|
-| Primary | 200K tokens | Complex reasoning, orchestration |
-| Explorer | 100K tokens | Code generation, analysis |
+- Install required skills: `superpowers:using-git-worktrees`, `superpowers:writing-plans`
+- Set `OPENROUTER_API_KEY` for multi-model access
+- Configure explorer models using IDs from `shared/model-aliases.json` (run `/update-models` to refresh)
 
 ## Workflow
 
-### Phase 0: Problem Analysis (200-300 words)
+### Phase 0: Problem Analysis
 
-**Objective**: Capture problem scope, constraints, and success criteria
+**Objective**: Capture problem scope, constraints, and success criteria.
 
-**How to Ask Users (Without AskUserQuestion)**:
+Present structured questions to the user via conversation (one at a time):
+1. What are the main constraints or requirements?
+2. What are the functional and non-functional requirements?
+3. Are there existing dependencies or integrations?
 
-```typescript
-// Pattern: Use Tasks to track questions, Read/Write for presentation
+Summarize the user's answers into a problem statement with constraints, success criteria, and scope boundaries. Confirm understanding before proceeding.
 
-// 1. Write question to temp file
-await Write({
-  file_path: "/tmp/brainstorm-q1.md",
-  content: `## Question 1 of 3
-
-**What are the main constraints or requirements for this feature?**
-
-Please respond with:
-- Functional requirements (what it must do)
-- Non-functional requirements (performance, scale)
-- Any existing dependencies or integrations
-`
-});
-
-// 2. Present file and wait for user response
-// User reads file, provides input via conversation
-
-// 3. Summarize understanding
-const problemSummary = await Write({
-  file_path: "/tmp/brainstorm-problem.md",
-  content: `## Problem Understanding
-
-**Constraints identified:**
-- [From user response]
-
-**Success criteria:**
-- [Measurable outcomes]
-
-**Scope boundaries:**
-- [What's in/out]
-
----
-
-**Does this accurately capture the problem?** (Reply "yes" to proceed or clarify)
-`
-});
-```
-
-**Gate Type**: USER_GATE (requires confirmation)
+**Gate**: USER_GATE — requires user confirmation.
 
 ---
 
 ### Phase 1: Parallel Exploration
 
-**Objective**: Generate diverse solutions via multi-model brainstorming
+**Objective**: Generate diverse solutions via multi-model brainstorming.
 
-**Fallback Chain Implementation**:
+Launch 3+ explorer models in parallel using Task calls. Use a fallback chain so that if one model fails, the next in the chain is tried. Continue with partial results if at least one model succeeds.
 
-```typescript
-interface ModelResult {
-  model: string;
-  success: boolean;
-  output?: string;
-  error?: string;
-}
+Each model should propose multiple approaches. For each approach, capture:
+- Name and one-sentence summary
+- Key components (bullet points)
+- Trade-offs (pros/cons)
+- Model's confidence score (0-100)
 
-async function exploreWithFallback(
-  prompt: string,
-  role: "explorer"
-): Promise<ModelResult> {
-  // Use model IDs from shared/model-aliases.json → teams.code or teams.review
-  // Run /update-models to refresh available models
-  const fallbackModels = role === "explorer"
-    ? [/* models from shared/model-aliases.json teams.code */]
-    : ["internal" /* plus models from teams.review */];
-
-  for (const model of fallbackModels) {
-    try {
-      const result = await Task({
-        model: model,
-        prompt: prompt,
-        timeout_ms: 120000  // 2 minute timeout
-      });
-
-      return { model, success: true, output: result };
-    } catch (error) {
-      console.warn(`Model ${model} failed:`, error.message);
-      continue;  // Try next in chain
-    }
-  }
-
-  throw new Error(`All models in fallback chain failed`);
-}
-```
-
-**Parallel Execution Pattern**:
-
-```typescript
-// WRONG: Sequential (slow)
-// const result1 = await Task({ model: "grok", ... });
-// const result2 = await Task({ model: "gemini", ... });
-// const result3 = await Task({ model: "sonnet", ... });
-
-// CORRECT: Parallel (3-5x faster)
-// Use model IDs from shared/model-aliases.json → teams.code (run /update-models to refresh)
-const [result1, result2, result3] = await Promise.all([
-  Task({
-    model: "(fast_coding role from shared/model-aliases.json)",
-    prompt: generateExplorerPrompt(problem, "fast_code")
-  }),
-  Task({
-    model: "(reasoning role from shared/model-aliases.json)",
-    prompt: generateExplorerPrompt(problem, "balanced")
-  }),
-  Task({
-    model: "(model from teams.code in shared/model-aliases.json)",
-    prompt: generateExplorerPrompt(problem, "thorough")
-  })
-]);
-
-// Handle partial failures
-const results = [result1, result2, result3].filter(r => r.success);
-if (results.length === 0) {
-  throw new Error("All exploration models failed");
-}
-```
-
-**Output Format**:
-```markdown
-## Approach: [Name]
-
-**Model**: [Which model generated this]
-**Approach Type**: [architecture/algorithm/pattern]
-**Summary**: 2-3 sentences
-
-**Key Components**:
-1. Component A
-2. Component B
-3. Component C
-
-**Trade-offs**:
-- + Advantage
-- - Disadvantage
-
-**Confidence**: [Model's confidence 0-100]
-```
-
-**Gate Type**: AUTO_GATE (automatic consolidation)
+**Gate**: AUTO_GATE — automatic consolidation of results.
 
 ---
 
 ### Phase 2: Consensus Analysis
 
-**Objective**: Identify strongest ideas using defined algorithms
+**Objective**: Identify strongest ideas by measuring cross-model agreement.
 
-**Consensus Matrix Algorithm**:
-1. **Clustering**: Group approaches by semantic similarity (vector embedding + clustering)
-2. **Scoring**: Count model agreement per cluster
-3. **Classification**: UNANIMOUS (3/3), STRONG (2/3), DIVERGENT (1/3)
-4. **Confidence**: Weighted average of model confidences + agreement bonus
+Algorithm:
+1. **Cluster** approaches by semantic similarity
+2. **Score agreement**: count how many models proposed similar approaches
+3. **Classify**: UNANIMOUS (all models agree), STRONG (majority), DIVERGENT (single model)
+4. **Calculate confidence**: average of model confidences + agreement bonus (up to +20%), minus diversity penalty
 
-**Consensus Matrix Calculation**:
+Present a consensus matrix showing each approach cluster, agreement level, and final confidence score. Rank by confidence descending.
 
-```typescript
-interface Approach {
-  id: string;
-  name: string;
-  summary: string;
-  model: string;  // Which model proposed
-  modelConfidence: number;  // 0-100
-  embedding: number[];  // For clustering
-}
-
-interface Cluster {
-  approaches: Approach[];
-  representative: Approach;  // Most complete
-  agreementScore: number;  // 0-1
-  confidenceScore: number;  // 0-100
-  consensusLevel: "UNANIMOUS" | "STRONG" | "DIVERGENT";
-}
-
-function calculateConsensus(approaches: Approach[]): Cluster[] {
-  // Step 1: Cluster by semantic similarity
-  const clusters = clusterByEmbedding(approaches, threshold: 0.85);
-
-  // Step 2: Calculate metrics per cluster
-  return clusters.map(cluster => {
-    const models = cluster.map(a => a.model);
-    const modelCount = new Set(models).size;
-    const totalModels = approaches.length;
-
-    // Agreement: proportion of models that have an approach in this cluster
-    const agreementScore = modelCount / totalModels;
-
-    // Confidence: weighted average + agreement bonus
-    const baseConfidence = cluster
-      .map(a => a.modelConfidence)
-      .reduce((a, b) => a + b, 0) / cluster.length;
-
-    const confidenceScore = Math.min(100,
-      baseConfidence + (agreementScore * 20)  // +20% for agreement
-    );
-
-    // Consensus classification
-    const consensusLevel = agreementScore >= 0.9 ? "UNANIMOUS" :
-                          agreementScore >= 0.5 ? "STRONG" :
-                          "DIVERGENT";
-
-    return {
-      approaches: cluster,
-      representative: cluster.reduce((best, current) =>
-        current.modelConfidence > best.modelConfidence ? current : best
-      ),
-      agreementScore,
-      confidenceScore: Math.round(confidenceScore),
-      consensusLevel
-    };
-  }).sort((a, b) => b.confidenceScore - a.confidenceScore);
-}
-```
-
-**Confidence Scoring Formula**:
-
-```
-Confidence = Base + AgreementBonus - DiversityPenalty
-
-Where:
-  Base = average(model confidences in cluster)
-  AgreementBonus = (unique_models / total_models) * 20
-  DiversityPenalty = (1 - similarity_coefficient) * 10
-
-Example:
-  3 models propose similar approaches
-  Base = (92 + 88 + 95) / 3 = 91.7
-  AgreementBonus = (3/3) * 20 = 20
-  DiversityPenalty = (1 - 0.9) * 10 = 1
-  Confidence = 91.7 + 20 - 1 = 110.7 -> capped at 100
-  Final: 97%
-```
-
-**Consensus Matrix Example**:
-
-| Approach | Grok | Gemini | Sonnet | Agreement | Confidence |
-|----------|------|--------|--------|-----------|------------|
-| Token Bucket | Yes | Yes | Yes | UNANIMOUS | 97% |
-| Leaky Bucket | Yes | Yes | No | STRONG | 82% |
-| Sliding Window | No | No | Yes | DIVERGENT | 45% |
-
-**Gate Type**: AUTO_GATE (automatic scoring)
+**Gate**: AUTO_GATE — automatic scoring.
 
 ---
 
 ### Phase 3: User Selection
 
-**Objective**: Present top approaches for user decision
+**Objective**: Present top approaches for user decision.
 
-**Presentation Pattern**:
+Show the top 3-5 approaches with their consensus level, confidence score, summary, and trade-offs. Offer the user choices:
+- Select a specific approach
+- Combine elements from multiple approaches
+- Return to Phase 1 for more exploration
 
-```typescript
-async function presentApproaches(clusters: Cluster[]): Promise<string> {
-  const topClusters = clusters.slice(0, 5);  // Top 5
-
-  let presentation = `## Top Approaches\n\n`;
-
-  for (const [index, cluster] of topClusters.entries()) {
-    const approach = cluster.representative;
-
-    presentation += `### ${String.fromCharCode(65 + index)}: ${approach.name} [${cluster.consensusLevel}]
-
-**Summary**: ${approach.summary}
-
-**Confidence**: ${cluster.confidenceScore}% (${cluster.approaches.length} model(s) agree)
-
-**Pros**:
-${cluster.approaches.map(a => `- ${a.summary}`).join("\n")}
-
-**Cons**:
-${cluster.approaches.map(a => `- Potential issue from ${a.model}`).join("\n")}
-
----
-`;
-  }
-
-  presentation += `
-## Your Choice
-
-Which approach best fits your requirements?
-
-- **A**: Select approach A
-- **B**: Select approach B
-- **C**: Select approach C
-- **D**: Combine elements from multiple
-- **E**: Explore alternatives (return to Phase 1)
-`;
-
-  // Save for user review
-  await Write({
-    file_path: "/tmp/brainstorm-approaches.md",
-    content: presentation
-  });
-
-  return presentation;
-}
-```
-
-**Gate Type**: USER_GATE (selection via conversation)
+**Gate**: USER_GATE — user selects via conversation.
 
 ---
 
 ### Phase 4: Detailed Planning
 
-**Objective**: Elaborate selected approach into actionable sections
+**Objective**: Elaborate selected approach into actionable sections.
 
-**Confidence-Based Gating**:
+Break the chosen approach into implementation sections (200-300 words each). Apply confidence-based gating per section:
 
-| Confidence | Gate Type | Action |
-|------------|-----------|--------|
-| >=95% | AUTO_GATE | Proceed automatically |
-| 80-94% | AUTO_GATE | Proceed with notification |
-| 60-79% | USER_GATE | Request confirmation |
-| <60% | USER_GATE | Require revision |
+| Confidence | Action |
+|------------|--------|
+| >= 95%     | Proceed automatically |
+| 60-94%     | Notify user, request confirmation if < 80% |
+| < 60%      | Require user revision |
 
-**Section Template**:
+Each section should include: implementation details, assumptions, and a confidence breakdown (technical feasibility, edge case coverage, team capability).
 
-```markdown
-## [Section Name] (Confidence: XX%)
-
-**Approach**: [Selected approach]
-
-**Implementation Details**:
-[200-300 words]
-
-**Assumptions**:
-- Assumption 1
-- Assumption 2
-
-**Confidence Calculation**:
-- Technical feasibility: XX%
-- Edge cases covered: XX%
-- Team capability: XX%
-- Overall: XX%
-
-**Status**: [AUTO_GATE|PENDING_USER] - [Reason]
-```
-
-**Gate Type**: MIXED_GATE (adaptive)
+**Gate**: MIXED_GATE — adaptive based on confidence.
 
 ---
 
 ### Phase 5: Plan Validation
 
-**Objective**: Final review before implementation
+**Objective**: Final review before implementation.
 
-**Validation Checklist**:
+Present a validation checklist:
+- Problem scope accurately captured
+- Chosen approach matches expectations
+- Module structure aligns with capabilities
+- Technical constraints addressed
+- Success criteria are measurable
 
-```markdown
-## Plan Validation
+User replies "approve" to finalize, "revise [section]" to modify, or "restart" to begin fresh.
 
-**Problem**: [Summary]
-**Approach**: [Selected]
-**Confidence**: [Overall]
-
-### Checklist
-
-- [ ] Problem scope accurately captured
-- [ ] Chosen approach matches expectations
-- [ ] Module structure aligns with capabilities
-- [ ] Technical constraints addressed
-- [ ] Success criteria measurable
-
-### Next Steps
-
-**To proceed**:
-1. Reply "approve" to finalize
-2. Reply "revise [section]" to modify
-3. Reply "restart" to begin fresh
-
-**Final decision?**
-```
-
-**Gate Type**: USER_GATE (explicit approval)
+**Gate**: USER_GATE — explicit approval required.
 
 ---
-
-## Complete Parallel Execution Example
-
-```typescript
-// Complete Phase 1 parallel exploration
-async function runParallelExploration(problem: string): Promise<Approach[]> {
-  // Use model IDs from shared/model-aliases.json → teams.code
-  // Run /update-models to refresh available models
-  const explorerModels = [
-    // fast_coding role — fast, code-focused
-    // reasoning role — balanced, creative
-    // another model from teams.code — thorough
-  ];
-
-  const prompts = explorerModels.map(model =>
-    `Generate 5 implementation approaches for: ${problem}
-
-For each approach provide:
-1. Name (2-3 words)
-2. One-sentence summary
-3. Key components (bullet points)
-4. Trade-offs (+/-)
-5. Your confidence (0-100)
-
-Format as JSON array.`
-  );
-
-  // LAUNCH ALL MODELS IN PARALLEL
-  const taskPromises = explorerModels.map((model, index) =>
-    Task({
-      model: model,
-      prompt: prompts[index],
-      timeout_ms: 120000,
-      max_turns: 1
-    }).catch(error => ({
-      model,
-      success: false,
-      error: error.message
-    }))
-  );
-
-  // WAIT FOR ALL TO COMPLETE
-  const results = await Promise.all(taskPromises);
-
-  // CONSOLIDATE SUCCESSFUL RESULTS
-  const approaches: Approach[] = results
-    .filter(r => r.success)
-    .flatMap(r => parseApproaches(r.output));
-
-  // HANDLE PARTIAL FAILURES
-  if (approaches.length < 5) {
-    console.warn(`Only got ${approaches.length} approaches from ${explorerModels.length} models`);
-    if (approaches.length === 0) {
-      throw new Error("All models failed");
-    }
-  }
-
-  return approaches;
-}
-```
 
 ## Troubleshooting
 
@@ -565,128 +132,22 @@ Format as JSON array.`
 
 | Symptom | Cause | Solution |
 |---------|-------|----------|
-| Single model fails | API error, timeout | Fallback chain handles automatically |
-| All models fail | API key issue, network | Check `OPENROUTER_API_KEY`, retry |
-| Partial results (2/3) | One model unavailable | Continue with available; lower diversity but valid |
-
-**Recovery Pattern**:
-```typescript
-async function resilientExploration(problem: string): Promise<Approach[]> {
-  let attempts = 0;
-  const maxAttempts = 3;
-
-  while (attempts < maxAttempts) {
-    try {
-      return await runParallelExploration(problem);
-    } catch (error) {
-      attempts++;
-      if (attempts === maxAttempts) throw error;
-
-      // Exponential backoff
-      await new Promise(r => setTimeout(r, Math.pow(2, attempts) * 1000));
-    }
-  }
-}
-```
+| Single model fails | API error or timeout | Fallback chain handles automatically |
+| All models fail | API key or network issue | Check `OPENROUTER_API_KEY`, retry |
+| Partial results | One model unavailable | Continue with available models |
 
 ### Consensus Issues
 
 | Symptom | Cause | Solution |
 |---------|-------|----------|
-| All approaches DIVERGENT | Models produce very different ideas | Not a failure - indicates novel problem |
-| Single cluster with 90%+ confidence | Problem is well-understood | Good for AUTO_GATE |
-| No clear winner | Multiple valid approaches | Present all to user |
+| All DIVERGENT | Models produce very different ideas | Not a failure — indicates novel problem space |
+| Single high-confidence cluster | Well-understood problem | Good candidate for AUTO_GATE |
+| No clear winner | Multiple valid approaches | Present all to user for decision |
 
 ### User Interaction Issues
 
 | Symptom | Cause | Solution |
 |---------|-------|----------|
 | User doesn't respond | Unclear question | Rewrite with specific format |
-| User provides conflicting answers | Multiple questions at once | Ask one at a time, confirm understanding |
-| User wants to restart | Dissatisfied with direction | Allow restart to Phase 0 |
-
----
-
-## Configuration
-
-### Environment Variables
-
-```bash
-# Required for multi-model
-OPENROUTER_API_KEY=...
-
-# Optional
-BRAINSTORM_TIMEOUT_MS=120000
-BRAINSTORM_MAX_RETRIES=2
-BRAINSTORM_MIN_MODELS=2  # Minimum models for valid consensus
-```
-
-### Model Configuration
-
-```json
-{
-  "brainstorming": {
-    "primary": ["internal"],
-    "explorers": {
-      // Use model IDs from shared/model-aliases.json (run /update-models to refresh)
-      "primary_chain": ["(model from teams.code)", "(model from teams.code)"],
-      "fallback_chain": ["(model from teams.review)", "(model from teams.review)"]
-    },
-    "thresholds": {
-      "auto_gate": 95,
-      "confirm_gate": 60
-    }
-  }
-}
-```
-
----
-
-## Performance
-
-| Metric | v1.0 | v2.0 | Improvement |
-|--------|------|------|-------------|
-| Model failure recovery | 0% | 95% | Fallback chains |
-| Consensus calculation | Undefined | Defined | Mathematically specified |
-| User interaction | AskUserQuestion | Task+Write | No tool dependency |
-| Parallel execution | Implicit | Explicit | Documented patterns |
-
----
-
-## Comparison: v1.0 vs v2.0
-
-| Aspect | v1.0 | v2.0 |
-|--------|------|------|
-| AskUserQuestion | Required | Removed |
-| Model fallbacks | None | 3+ per role |
-| Parallel pattern | Described | Code example |
-| Consensus algorithm | Table example | Full implementation |
-| Confidence formula | Mentioned | Math specified |
-| Troubleshooting | 4 items | 10+ items |
-| Prerequisites | None | Setup guide |
-
----
-
-## Version History
-
-**v2.0.0** (2026-01-30):
-- Removed AskUserQuestion dependency
-- Added model fallback chains
-- Explicit parallel execution patterns
-- Defined consensus matrix algorithm
-- Added confidence scoring formula
-- Added prerequisites and setup guide
-- Expanded troubleshooting section
-- Winner of blind multi-model voting (3/3 votes, avg confidence 8.7/10)
-
-**v1.0.0** (2026-01-30):
-- Initial release
-- 6-phase workflow
-- Multi-model exploration
-- Confidence-based gating
-
----
-
-**Status**: v2.0 Ready for use
-**Tested**: Fallback chains, parallel execution, consensus algorithm
-**Known Limitations**: Requires OpenRouter for multi-model access
+| Conflicting answers | Too many questions at once | Ask one at a time |
+| User wants to restart | Dissatisfied with direction | Return to Phase 0 |


### PR DESCRIPTION
Hey @erudenko 👋

I ran your skills through `tessl skill review` at work and found some targeted improvements.


<img width="1312" height="910" alt="image" src="https://github.com/user-attachments/assets/c850c801-1074-4902-b753-0e5c45860d99" />


 Here's the full before/after:

| Skill | Before | After | Change |
|-------|--------|-------|--------|
| brainstorming | 32% | 81% | +49% |
| setup | 36% | 90% | +54% |
| new-track | 42% | 90% | +48% |
| help | 45% | 93% | +48% |
| revert | 45% | 84% | +39% |

This PR is intentionally scoped to the 5 lowest-scoring skills to keep things reviewable — more skills can be improved in follow-ups or via automated review on future PRs.

<details>
<summary>Changes summary</summary>

**brainstorming** (32% → 81%)
- Rewrote description with concrete actions and "Use when..." clause (was abstract jargon)
- Cut content from 693 → 153 lines (78% reduction) — removed v1/v2 comparisons, version history, performance tables, non-executable TypeScript pseudocode
- Cleaned frontmatter: removed non-standard keys (dependencies, parameters, gates)
- Kept core 6-phase workflow in concise form

**setup** (36% → 90%)
- Rewrote description with "Use when..." clause (was opaque one-liner)
- Replaced all XML markup with lean markdown (242 → 166 lines)
- Removed unnecessary sections: role/identity block, greenfield vs brownfield definitions, question type explanations
- Added concrete artifact templates for product.md and tech-stack.md
- Added validation steps after artifact generation

**new-track** (42% → 90%)
- Rewrote description with "Use when..." clause and concrete actions
- Replaced all XML with clean markdown (261 → ~150 lines)
- Removed role block and stray metadata outside frontmatter
- Preserved spec/plan templates, workflow phases, and examples in streamlined form

**help** (45% → 93%)
- Rewrote description with specific command names and "Use when..." clause
- Removed Philosophy, Example Requests, and Getting Help sections (token waste)
- Added validation checkpoints to Quick Start workflow
- Added cross-references to detailed skill files for progressive disclosure
- Converted troubleshooting to concise table format

**revert** (45% → 84%)
- Rewrote description with "Use when..." clause covering undo/rollback/revert triggers
- Replaced all XML with clean markdown (240 → 117 lines)
- Removed role block and stray metadata
- Preserved 5-phase workflow, revert strategies, examples, and templates

</details>

Honest disclosure — I work at @tesslio where we build tooling around skills like these. Not a pitch - just saw room for improvement and wanted to contribute.

Want to self-improve your skills? Just point your agent (Claude Code, Codex, etc.) at [this Tessl guide](https://docs.tessl.io/evaluate/optimize-a-skill-using-best-practices) and ask it to optimize your skill. Ping me - [@rohan-tessl](https://github.com/rohan-tessl) - if you hit any snags.

Thanks in advance 🙏
