### PR TITLE
fix(ci): remove 3 remaining unused TS imports [runs 24040412326, 24040412328]

### DIFF
--- a/tools/claudeup-core/src/__tests__/integration/conventions-integration.test.ts
+++ b/tools/claudeup-core/src/__tests__/integration/conventions-integration.test.ts
@@ -32,7 +32,6 @@ import { tmpdir } from 'node:os';
 import {
   // Gitignore operations
   ensureGitignoreEntries,
-  removeGitignoreEntries,
   checkGitignoreEntries,
   // CLAUDE.md operations
   parseClaudeMdSections,

--- a/tools/claudeup-core/src/__tests__/unit/doctor.test.ts
+++ b/tools/claudeup-core/src/__tests__/unit/doctor.test.ts
@@ -10,7 +10,7 @@
  * with real plugin.json files. runDoctor is tested by mocking the registry.
  */
 
-import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { mkdtemp, rm, writeFile, readFile, mkdir } from 'node:fs/promises';
 import { existsSync } from 'node:fs';
 import { tmpdir } from 'node:os';

--- a/tools/claudeup-core/src/services/conventions-manager.ts
+++ b/tools/claudeup-core/src/services/conventions-manager.ts
@@ -14,7 +14,6 @@
  */
 
 import { readFile, writeFile, stat, rename, unlink, open } from 'node:fs/promises';
-import { existsSync } from 'node:fs';
 import { randomUUID } from 'node:crypto';
 import { dirname, basename, join, resolve } from 'node:path';
 import { homedir } from 'node:os';


### PR DESCRIPTION
## What failed

CI runs [24040412326](https://github.com/MadAppGang/magus/actions/runs/24040412326) (Test Stats Plugin) and [24040412328](https://github.com/MadAppGang/magus/actions/runs/24040412328) (Test Plugins) on branch `fix/ci-type-errors-and-stale-test-date`.

The base branch (`fix/ci-type-errors-and-stale-test-date`) only fixed one of the four unused imports (`InstalledPluginEntry` in `doctor.ts`). TypeScript's `noUnusedLocals: true` still flagged three more.

## What this PR fixes

Three remaining unused imports removed:

| File | Import removed |
|------|---------------|
| `tools/claudeup-core/src/services/conventions-manager.ts` | `existsSync` |
| `tools/claudeup-core/src/__tests__/unit/doctor.test.ts` | `vi` (from vitest) |
| `tools/claudeup-core/src/__tests__/integration/conventions-integration.test.ts` | `removeGitignoreEntries` |

## Why this is safe

All three imports are confirmed unused:
- `existsSync` in `conventions-manager.ts`: removed from node:fs import; not referenced anywhere in the file
- `vi` in `doctor.test.ts`: no `vi.mock()`/`vi.fn()` calls in the file
- `removeGitignoreEntries` in `conventions-integration.test.ts`: function is imported but never called in test

Part of the work tracked in #18.