### PR TITLE
fix(ci): remove unused TS imports + fix stale stats test dates

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -442,8 +442,8 @@
         "ref": "main",
         "sha": "af9911e626dd1406295b20c8e4d80f52ff3d8266"
       },
-      "description": "Kanban board view for task management. v1.2.0: Word-wrapped titles, full-width boards, even column distribution. Visual board with 5 columns, task dependencies (cycle-safe), priority indicators, WIP limits. Shares tasks.json with GTD plugin \u2014 works standalone or alongside GTD.",
-      "version": "1.2.0",
+      "description": "Kanban board view for task management. v1.3.0: Auto-open board in tmux split pane with real TTY, smart terminal width detection chain (stdout/COLUMNS/tmux/parent-TTY/120), remove --width hack. Visual board with 5 columns, task dependencies (cycle-safe), priority indicators, WIP limits. Shares tasks.json with GTD plugin \u2014 works standalone or alongside GTD.",
+      "version": "1.3.0",
       "author": {
         "name": "Jack Rudenko",
         "email": "i@madappgang.com",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -18,7 +18,7 @@
         "url": "MadAppGang/magus",
         "path": "plugins/code-analysis",
         "ref": "main",
-        "sha": "4bac22cba2a12ce92331a11938235b45764bcc25"
+        "sha": "6053b7d375250b0e14fc968f8ef44cccbd614e9a"
       },
       "description": "Deep code investigation with mnemex MCP server. v5.0.1: Renamed mnemex CLI tool.",
       "version": "5.1.0",
@@ -52,7 +52,7 @@
         "url": "MadAppGang/magus",
         "path": "plugins/multimodel",
         "ref": "main",
-        "sha": "4bac22cba2a12ce92331a11938235b45764bcc25"
+        "sha": "6053b7d375250b0e14fc968f8ef44cccbd614e9a"
       },
       "description": "Multi-model collaboration, orchestration, and workflow patterns. v3.1.2: Fix internal model leaked to claudish \u2014 filter sentinel before external dispatch.",
       "version": "3.1.2",
@@ -87,7 +87,7 @@
         "url": "MadAppGang/magus",
         "path": "plugins/agentdev",
         "ref": "main",
-        "sha": "4bac22cba2a12ce92331a11938235b45764bcc25"
+        "sha": "6053b7d375250b0e14fc968f8ef44cccbd614e9a"
       },
       "description": "Create, implement, and review Claude Code agents and commands with multi-model validation, LLM performance tracking, and session-based artifact isolation. v1.6.1: Fix manifest schema \u2014 agents paths, hooks format.",
       "version": "1.6.1",
@@ -118,7 +118,7 @@
         "url": "MadAppGang/magus",
         "path": "plugins/seo",
         "ref": "main",
-        "sha": "4bac22cba2a12ce92331a11938235b45764bcc25"
+        "sha": "6053b7d375250b0e14fc968f8ef44cccbd614e9a"
       },
       "description": "Highly autonomous SEO toolkit (~80% autonomy) with AUTO GATEs, self-correction loops, and multi-model validation. v1.6.5: Command parameter fixes.",
       "version": "1.7.0",
@@ -148,7 +148,7 @@
         "url": "MadAppGang/magus",
         "path": "plugins/video-editing",
         "ref": "main",
-        "sha": "4bac22cba2a12ce92331a11938235b45764bcc25"
+        "sha": "6053b7d375250b0e14fc968f8ef44cccbd614e9a"
       },
       "description": "Professional video editing toolkit with FFmpeg operations, Whisper transcription, and Apple Final Cut Pro project generation. v1.1.1: Marketplace rename to magus. Features intelligent video analysis, automated transcription with timing sync, FCPXML timeline creation.",
       "version": "1.1.3",
@@ -179,7 +179,7 @@
         "url": "MadAppGang/magus",
         "path": "plugins/nanobanana",
         "ref": "main",
-        "sha": "4bac22cba2a12ce92331a11938235b45764bcc25"
+        "sha": "6053b7d375250b0e14fc968f8ef44cccbd614e9a"
       },
       "description": "AI image generation and editing using Google Gemini 3 Pro Image API. v2.3.1: Marketplace rename to magus. Simple Node.js CLI with markdown styles and batch generation.",
       "version": "2.4.0",
@@ -208,7 +208,7 @@
         "url": "MadAppGang/magus",
         "path": "plugins/conductor",
         "ref": "main",
-        "sha": "4bac22cba2a12ce92331a11938235b45764bcc25"
+        "sha": "6053b7d375250b0e14fc968f8ef44cccbd614e9a"
       },
       "description": "Context-Driven Development workflow inspired by Gemini Conductor. v2.1.3: Fix manifest schema \u2014 commands paths, add skills registration.",
       "version": "2.1.3",
@@ -239,7 +239,7 @@
         "url": "MadAppGang/magus",
         "path": "plugins/dev",
         "ref": "main",
-        "sha": "4bac22cba2a12ce92331a11938235b45764bcc25"
+        "sha": "6053b7d375250b0e14fc968f8ef44cccbd614e9a"
       },
       "description": "Universal development assistant. v2.6.0: self-learning Stop hook \u2014 automated session learning with LLM classifier, background daemon, /dev:learn --apply/--prune.",
       "version": "2.7.0",
@@ -288,7 +288,7 @@
         "url": "MadAppGang/magus",
         "path": "plugins/statusline",
         "ref": "main",
-        "sha": "4bac22cba2a12ce92331a11938235b45764bcc25"
+        "sha": "6053b7d375250b0e14fc968f8ef44cccbd614e9a"
       },
       "description": "Adaptive statusline \u2014 always-visible bars, background highlights for critical states, provider-aware model display, vim mode, diff stats, compaction count, memory usage. v2.1.0: Prominent reset countdowns when rate-limited, process memory display.",
       "version": "2.1.0",
@@ -316,7 +316,7 @@
         "url": "MadAppGang/magus",
         "path": "plugins/browser-use",
         "ref": "main",
-        "sha": "4bac22cba2a12ce92331a11938235b45764bcc25"
+        "sha": "6053b7d375250b0e14fc968f8ef44cccbd614e9a"
       },
       "description": "Full-platform browser automation for Claude Code. v1.1.0: Thin wrapper over built-in BrowserUseServer \u2014 63% less code. Fix TCC downloads_path, per-PID Chrome profiles, graceful shutdown. 19 MCP tools, 5 skills.",
       "version": "1.1.1",
@@ -348,7 +348,7 @@
         "url": "MadAppGang/magus",
         "path": "plugins/designer",
         "ref": "main",
-        "sha": "4bac22cba2a12ce92331a11938235b45764bcc25"
+        "sha": "6053b7d375250b0e14fc968f8ef44cccbd614e9a"
       },
       "description": "UI design validation with pixel-diff comparison engine. v0.2.0: Design review agent, visual comparison, style guide creation, browser-use optional integration. 6 skills.",
       "version": "0.3.0",
@@ -380,7 +380,7 @@
         "url": "MadAppGang/magus",
         "path": "plugins/terminal",
         "ref": "main",
-        "sha": "4bac22cba2a12ce92331a11938235b45764bcc25"
+        "sha": "6053b7d375250b0e14fc968f8ef44cccbd614e9a"
       },
       "description": "Interactive terminal integration for Claude Code. v4.0.0: agentic-first rewrite \u2014 single Go tmux-mcp binary replaces ht-mcp + npm tmux-mcp. New agentic tools (start-and-watch, watch-pane, run-in-repl, pane-state) eliminate all polling loops. 5 skills, 9 commands, 1 agent.",
       "version": "4.0.2",
@@ -409,7 +409,7 @@
         "url": "MadAppGang/magus",
         "path": "plugins/gtd",
         "ref": "main",
-        "sha": "4bac22cba2a12ce92331a11938235b45764bcc25"
+        "sha": "6053b7d375250b0e14fc968f8ef44cccbd614e9a"
       },
       "description": "GTD (Getting Things Done) workflow integration. v2.0.0: Canonical GTD terminology (Clarify, Engage), sequential task IDs (#1, #2), boxed terminal display, reference list, Bun display tool. Real-time sync via hooks, 7 commands, 2 skills.",
       "version": "2.0.1",
@@ -440,7 +440,7 @@
         "url": "MadAppGang/magus",
         "path": "plugins/kanban",
         "ref": "main",
-        "sha": "4bac22cba2a12ce92331a11938235b45764bcc25"
+        "sha": "6053b7d375250b0e14fc968f8ef44cccbd614e9a"
       },
       "description": "Kanban board view for task management. v1.3.0: Auto-open board in tmux split pane with real TTY, smart terminal width detection chain (stdout/COLUMNS/tmux/parent-TTY/120), remove --width hack. Visual board with 5 columns, task dependencies (cycle-safe), priority indicators, WIP limits. Shares tasks.json with GTD plugin \u2014 works standalone or alongside GTD.",
       "version": "1.3.0",
@@ -470,7 +470,7 @@
         "url": "MadAppGang/magus",
         "path": "plugins/autopilot",
         "ref": "main",
-        "sha": "4bac22cba2a12ce92331a11938235b45764bcc25"
+        "sha": "6053b7d375250b0e14fc968f8ef44cccbd614e9a"
       },
       "description": "Autonomous task execution with Linear integration. Picks tasks from Linear, routes to agents via tag-to-command mapping, generates proof-of-work artifacts, and handles feedback loops.",
       "version": "0.2.4",
@@ -500,7 +500,7 @@
         "url": "MadAppGang/magus",
         "path": "plugins/instantly",
         "ref": "main",
-        "sha": "4bac22cba2a12ce92331a11938235b45764bcc25"
+        "sha": "6053b7d375250b0e14fc968f8ef44cccbd614e9a"
       },
       "description": "Cold email outreach toolkit with Instantly.ai MCP integration. Campaign analytics, sequence building, A/B testing, lead management, and auto-optimization.",
       "version": "1.0.6",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -18,7 +18,7 @@
         "url": "MadAppGang/magus",
         "path": "plugins/code-analysis",
         "ref": "main",
-        "sha": "af9911e626dd1406295b20c8e4d80f52ff3d8266"
+        "sha": "4bac22cba2a12ce92331a11938235b45764bcc25"
       },
       "description": "Deep code investigation with mnemex MCP server. v5.0.1: Renamed mnemex CLI tool.",
       "version": "5.1.0",
@@ -52,7 +52,7 @@
         "url": "MadAppGang/magus",
         "path": "plugins/multimodel",
         "ref": "main",
-        "sha": "af9911e626dd1406295b20c8e4d80f52ff3d8266"
+        "sha": "4bac22cba2a12ce92331a11938235b45764bcc25"
       },
       "description": "Multi-model collaboration, orchestration, and workflow patterns. v3.1.2: Fix internal model leaked to claudish \u2014 filter sentinel before external dispatch.",
       "version": "3.1.2",
@@ -87,7 +87,7 @@
         "url": "MadAppGang/magus",
         "path": "plugins/agentdev",
         "ref": "main",
-        "sha": "af9911e626dd1406295b20c8e4d80f52ff3d8266"
+        "sha": "4bac22cba2a12ce92331a11938235b45764bcc25"
       },
       "description": "Create, implement, and review Claude Code agents and commands with multi-model validation, LLM performance tracking, and session-based artifact isolation. v1.6.1: Fix manifest schema \u2014 agents paths, hooks format.",
       "version": "1.6.1",
@@ -118,7 +118,7 @@
         "url": "MadAppGang/magus",
         "path": "plugins/seo",
         "ref": "main",
-        "sha": "af9911e626dd1406295b20c8e4d80f52ff3d8266"
+        "sha": "4bac22cba2a12ce92331a11938235b45764bcc25"
       },
       "description": "Highly autonomous SEO toolkit (~80% autonomy) with AUTO GATEs, self-correction loops, and multi-model validation. v1.6.5: Command parameter fixes.",
       "version": "1.7.0",
@@ -148,7 +148,7 @@
         "url": "MadAppGang/magus",
         "path": "plugins/video-editing",
         "ref": "main",
-        "sha": "af9911e626dd1406295b20c8e4d80f52ff3d8266"
+        "sha": "4bac22cba2a12ce92331a11938235b45764bcc25"
       },
       "description": "Professional video editing toolkit with FFmpeg operations, Whisper transcription, and Apple Final Cut Pro project generation. v1.1.1: Marketplace rename to magus. Features intelligent video analysis, automated transcription with timing sync, FCPXML timeline creation.",
       "version": "1.1.3",
@@ -179,7 +179,7 @@
         "url": "MadAppGang/magus",
         "path": "plugins/nanobanana",
         "ref": "main",
-        "sha": "af9911e626dd1406295b20c8e4d80f52ff3d8266"
+        "sha": "4bac22cba2a12ce92331a11938235b45764bcc25"
       },
       "description": "AI image generation and editing using Google Gemini 3 Pro Image API. v2.3.1: Marketplace rename to magus. Simple Node.js CLI with markdown styles and batch generation.",
       "version": "2.4.0",
@@ -208,7 +208,7 @@
         "url": "MadAppGang/magus",
         "path": "plugins/conductor",
         "ref": "main",
-        "sha": "af9911e626dd1406295b20c8e4d80f52ff3d8266"
+        "sha": "4bac22cba2a12ce92331a11938235b45764bcc25"
       },
       "description": "Context-Driven Development workflow inspired by Gemini Conductor. v2.1.3: Fix manifest schema \u2014 commands paths, add skills registration.",
       "version": "2.1.3",
@@ -239,7 +239,7 @@
         "url": "MadAppGang/magus",
         "path": "plugins/dev",
         "ref": "main",
-        "sha": "af9911e626dd1406295b20c8e4d80f52ff3d8266"
+        "sha": "4bac22cba2a12ce92331a11938235b45764bcc25"
       },
       "description": "Universal development assistant. v2.6.0: self-learning Stop hook \u2014 automated session learning with LLM classifier, background daemon, /dev:learn --apply/--prune.",
       "version": "2.7.0",
@@ -288,7 +288,7 @@
         "url": "MadAppGang/magus",
         "path": "plugins/statusline",
         "ref": "main",
-        "sha": "af9911e626dd1406295b20c8e4d80f52ff3d8266"
+        "sha": "4bac22cba2a12ce92331a11938235b45764bcc25"
       },
       "description": "Adaptive statusline \u2014 always-visible bars, background highlights for critical states, provider-aware model display, vim mode, diff stats, compaction count, memory usage. v2.1.0: Prominent reset countdowns when rate-limited, process memory display.",
       "version": "2.1.0",
@@ -316,7 +316,7 @@
         "url": "MadAppGang/magus",
         "path": "plugins/browser-use",
         "ref": "main",
-        "sha": "af9911e626dd1406295b20c8e4d80f52ff3d8266"
+        "sha": "4bac22cba2a12ce92331a11938235b45764bcc25"
       },
       "description": "Full-platform browser automation for Claude Code. v1.1.0: Thin wrapper over built-in BrowserUseServer \u2014 63% less code. Fix TCC downloads_path, per-PID Chrome profiles, graceful shutdown. 19 MCP tools, 5 skills.",
       "version": "1.1.1",
@@ -348,7 +348,7 @@
         "url": "MadAppGang/magus",
         "path": "plugins/designer",
         "ref": "main",
-        "sha": "af9911e626dd1406295b20c8e4d80f52ff3d8266"
+        "sha": "4bac22cba2a12ce92331a11938235b45764bcc25"
       },
       "description": "UI design validation with pixel-diff comparison engine. v0.2.0: Design review agent, visual comparison, style guide creation, browser-use optional integration. 6 skills.",
       "version": "0.3.0",
@@ -380,7 +380,7 @@
         "url": "MadAppGang/magus",
         "path": "plugins/terminal",
         "ref": "main",
-        "sha": "af9911e626dd1406295b20c8e4d80f52ff3d8266"
+        "sha": "4bac22cba2a12ce92331a11938235b45764bcc25"
       },
       "description": "Interactive terminal integration for Claude Code. v4.0.0: agentic-first rewrite \u2014 single Go tmux-mcp binary replaces ht-mcp + npm tmux-mcp. New agentic tools (start-and-watch, watch-pane, run-in-repl, pane-state) eliminate all polling loops. 5 skills, 9 commands, 1 agent.",
       "version": "4.0.2",
@@ -409,7 +409,7 @@
         "url": "MadAppGang/magus",
         "path": "plugins/gtd",
         "ref": "main",
-        "sha": "af9911e626dd1406295b20c8e4d80f52ff3d8266"
+        "sha": "4bac22cba2a12ce92331a11938235b45764bcc25"
       },
       "description": "GTD (Getting Things Done) workflow integration. v2.0.0: Canonical GTD terminology (Clarify, Engage), sequential task IDs (#1, #2), boxed terminal display, reference list, Bun display tool. Real-time sync via hooks, 7 commands, 2 skills.",
       "version": "2.0.1",
@@ -440,7 +440,7 @@
         "url": "MadAppGang/magus",
         "path": "plugins/kanban",
         "ref": "main",
-        "sha": "af9911e626dd1406295b20c8e4d80f52ff3d8266"
+        "sha": "4bac22cba2a12ce92331a11938235b45764bcc25"
       },
       "description": "Kanban board view for task management. v1.3.0: Auto-open board in tmux split pane with real TTY, smart terminal width detection chain (stdout/COLUMNS/tmux/parent-TTY/120), remove --width hack. Visual board with 5 columns, task dependencies (cycle-safe), priority indicators, WIP limits. Shares tasks.json with GTD plugin \u2014 works standalone or alongside GTD.",
       "version": "1.3.0",
@@ -470,7 +470,7 @@
         "url": "MadAppGang/magus",
         "path": "plugins/autopilot",
         "ref": "main",
-        "sha": "af9911e626dd1406295b20c8e4d80f52ff3d8266"
+        "sha": "4bac22cba2a12ce92331a11938235b45764bcc25"
       },
       "description": "Autonomous task execution with Linear integration. Picks tasks from Linear, routes to agents via tag-to-command mapping, generates proof-of-work artifacts, and handles feedback loops.",
       "version": "0.2.4",
@@ -500,7 +500,7 @@
         "url": "MadAppGang/magus",
         "path": "plugins/instantly",
         "ref": "main",
-        "sha": "af9911e626dd1406295b20c8e4d80f52ff3d8266"
+        "sha": "4bac22cba2a12ce92331a11938235b45764bcc25"
       },
       "description": "Cold email outreach toolkit with Instantly.ai MCP integration. Campaign analytics, sequence building, A/B testing, lead management, and auto-optimization.",
       "version": "1.0.6",

--- a/plugins/gtd/lib/table.ts
+++ b/plugins/gtd/lib/table.ts
@@ -14,6 +14,8 @@
  *   Output:     print
  */
 
+import { execSync } from "child_process";
+
 // ── ANSI helpers ─────────────────────────────────────────────────────────────
 
 export const S = {
@@ -54,11 +56,64 @@ export function fg(style: string, text: string): string {
 
 // ── Text utilities ────────────────────────────────────────────────────────────
 
-/** Terminal width. Checks stdout, COLUMNS env var, defaults to 80. */
+/**
+ * Terminal width detection chain.
+ *
+ * Tries, in order:
+ *   1. process.stdout.columns (works when stdout is a TTY)
+ *   2. $COLUMNS env var (set by some shells / wrappers)
+ *   3. tmux pane_width (most accurate when inside a tmux pane)
+ *   4. Parent process TTY via stty (works when our own stdout is piped)
+ *   5. Fallback to 120 (reasonable default for modern terminals)
+ *
+ * Every shell-out is wrapped in try/catch so failures fall through silently.
+ */
 export function termW(): number {
-  return process.stdout.columns
-    || (process.env.COLUMNS ? parseInt(process.env.COLUMNS) : 0)
-    || 80;
+  // 1. Direct stdout columns
+  if (process.stdout.columns && process.stdout.columns > 0) {
+    return process.stdout.columns;
+  }
+
+  // 2. $COLUMNS env var
+  const envCols = process.env.COLUMNS ? parseInt(process.env.COLUMNS, 10) : 0;
+  if (envCols > 0) return envCols;
+
+  // 3. tmux pane width (only when TMUX env is set)
+  if (process.env.TMUX) {
+    try {
+      const w = parseInt(
+        execSync("tmux display-message -p '#{pane_width}'", { stdio: ["pipe", "pipe", "pipe"] })
+          .toString()
+          .trim(),
+        10,
+      );
+      if (w > 0) return w;
+    } catch { /* not in tmux or tmux unavailable */ }
+  }
+
+  // 4. Parent process TTY via stty
+  try {
+    const ppid = process.ppid ?? process.env.PPID;
+    if (ppid) {
+      const ttyName = execSync(`ps -o tty= -p ${ppid}`, { stdio: ["pipe", "pipe", "pipe"] })
+        .toString()
+        .trim();
+      if (ttyName && ttyName !== "?" && ttyName !== "??") {
+        const devPath = ttyName.startsWith("/dev/") ? ttyName : `/dev/${ttyName}`;
+        const sttyOut = execSync(`stty size < ${devPath}`, {
+          stdio: ["pipe", "pipe", "pipe"],
+          shell: "/bin/sh",
+        })
+          .toString()
+          .trim();
+        const cols = parseInt(sttyOut.split(/\s+/)[1], 10);
+        if (cols > 0) return cols;
+      }
+    }
+  } catch { /* no parent TTY or stty failed */ }
+
+  // 5. Fallback
+  return 120;
 }
 
 /** Remove all ANSI escape codes from text. */

--- a/plugins/kanban/commands/board.md
+++ b/plugins/kanban/commands/board.md
@@ -27,7 +27,7 @@ KANBAN_LIB="${CLAUDE_PLUGIN_ROOT}/hooks/kanban-lib.sh"
 bash -c "source \"${KANBAN_LIB}\" && CWD=\"${CWD}\" kanban_init"
 
 # Build display args
-DISPLAY_ARGS="board"
+DISPLAY_ARGS=""
 FILTER_CONTEXT=""   # e.g. "@code" or ""
 FILTER_PROJECT=""   # e.g. "5" (numeric ID) or ""
 COMPACT=false       # true if --compact
@@ -36,9 +36,10 @@ COMPACT=false       # true if --compact
 [ -n "$FILTER_PROJECT" ] && DISPLAY_ARGS="$DISPLAY_ARGS --project $FILTER_PROJECT"
 [ "$COMPACT" = "true" ] && DISPLAY_ARGS="$DISPLAY_ARGS --compact"
 
-TERM_WIDTH=$(tput cols 2>/dev/null || echo 80)
-bun run "${CLAUDE_PLUGIN_ROOT}/tools/kanban-display.ts" $DISPLAY_ARGS --file "$GTD_FILE" --width "$TERM_WIDTH"
+bun run "${CLAUDE_PLUGIN_ROOT}/tools/kanban-display.ts" board $DISPLAY_ARGS --file "$GTD_FILE"
 ```
+
+The display tool automatically opens in a tmux split pane when tmux is available. Any keypress closes the pane.
 
 ## After Showing the Board
 

--- a/plugins/kanban/lib/table.ts
+++ b/plugins/kanban/lib/table.ts
@@ -14,6 +14,8 @@
  *   Output:     print
  */
 
+import { execSync } from "child_process";
+
 // ── ANSI helpers ─────────────────────────────────────────────────────────────
 
 export const S = {
@@ -54,11 +56,64 @@ export function fg(style: string, text: string): string {
 
 // ── Text utilities ────────────────────────────────────────────────────────────
 
-/** Terminal width. Checks stdout, COLUMNS env var, defaults to 80. */
+/**
+ * Terminal width detection chain.
+ *
+ * Tries, in order:
+ *   1. process.stdout.columns (works when stdout is a TTY)
+ *   2. $COLUMNS env var (set by some shells / wrappers)
+ *   3. tmux pane_width (most accurate when inside a tmux pane)
+ *   4. Parent process TTY via stty (works when our own stdout is piped)
+ *   5. Fallback to 120 (reasonable default for modern terminals)
+ *
+ * Every shell-out is wrapped in try/catch so failures fall through silently.
+ */
 export function termW(): number {
-  return process.stdout.columns
-    || (process.env.COLUMNS ? parseInt(process.env.COLUMNS) : 0)
-    || 80;
+  // 1. Direct stdout columns
+  if (process.stdout.columns && process.stdout.columns > 0) {
+    return process.stdout.columns;
+  }
+
+  // 2. $COLUMNS env var
+  const envCols = process.env.COLUMNS ? parseInt(process.env.COLUMNS, 10) : 0;
+  if (envCols > 0) return envCols;
+
+  // 3. tmux pane width (only when TMUX env is set)
+  if (process.env.TMUX) {
+    try {
+      const w = parseInt(
+        execSync("tmux display-message -p '#{pane_width}'", { stdio: ["pipe", "pipe", "pipe"] })
+          .toString()
+          .trim(),
+        10,
+      );
+      if (w > 0) return w;
+    } catch { /* not in tmux or tmux unavailable */ }
+  }
+
+  // 4. Parent process TTY via stty
+  try {
+    const ppid = process.ppid ?? process.env.PPID;
+    if (ppid) {
+      const ttyName = execSync(`ps -o tty= -p ${ppid}`, { stdio: ["pipe", "pipe", "pipe"] })
+        .toString()
+        .trim();
+      if (ttyName && ttyName !== "?" && ttyName !== "??") {
+        const devPath = ttyName.startsWith("/dev/") ? ttyName : `/dev/${ttyName}`;
+        const sttyOut = execSync(`stty size < ${devPath}`, {
+          stdio: ["pipe", "pipe", "pipe"],
+          shell: "/bin/sh",
+        })
+          .toString()
+          .trim();
+        const cols = parseInt(sttyOut.split(/\s+/)[1], 10);
+        if (cols > 0) return cols;
+      }
+    }
+  } catch { /* no parent TTY or stty failed */ }
+
+  // 5. Fallback
+  return 120;
 }
 
 /** Remove all ANSI escape codes from text. */

--- a/plugins/kanban/plugin.json
+++ b/plugins/kanban/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "kanban",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "Kanban board view for task management. Works with the same tasks.json as the GTD plugin. Provides board visualization, task dependencies, status flow, and optional MCP sync.",
   "author": { "name": "Jack Rudenko", "email": "i@madappgang.com", "company": "MadAppGang" },
   "license": "MIT",

--- a/plugins/kanban/tools/kanban-display.ts
+++ b/plugins/kanban/tools/kanban-display.ts
@@ -19,9 +19,9 @@
  *   --project <id>           Filter board by project ID
  *   --compact                Compact board display
  *   --mode simple|regular|modern   Board rendering mode (default: regular)
- *   --width <n>              Override terminal width
  */
 
+import { execSync } from "child_process";
 import {
   S,
   fg,
@@ -140,7 +140,7 @@ function wordWrap(text: string, maxWidth: number): string[] {
   return lines;
 }
 
-/** Resolve effective terminal width (respects --width override via COLUMNS env). */
+/** Resolve effective terminal width. */
 function getTermWidth(): number {
   return termW();
 }
@@ -892,15 +892,56 @@ function cmdAdded(taskId: string, title: string): void {
 
 // ── CLI Entry Point ──────────────────────────────────────────────────────────
 
+/**
+ * When running the "board" command without a TTY (e.g. from Claude Code's Bash tool)
+ * and tmux is available, re-exec ourselves inside a tmux split pane so we get a real
+ * TTY with proper terminal width. The pane waits for a keypress then closes.
+ */
+function maybeReopenInTmux(args: string[]): boolean {
+  if (args[0] !== "board") return false;
+  if (process.stdout.isTTY) return false;
+  if (!process.env.TMUX) return false;
+
+  // Determine split direction based on current pane count
+  let paneCount = 1;
+  try {
+    paneCount = parseInt(
+      execSync("tmux list-panes | wc -l", { stdio: ["pipe", "pipe", "pipe"] }).toString().trim(),
+      10,
+    ) || 1;
+  } catch { /* default to 1 */ }
+
+  const splitDir = paneCount <= 1 ? "-h" : paneCount <= 2 ? "-v" : "-h";
+  const splitSize = paneCount <= 2 ? "50%" : "40%";
+
+  // Re-invoke ourselves with the same args inside a tmux split pane
+  const script = process.argv[1];
+  const escapedArgs = args.map(a => `'${a.replace(/'/g, "'\\''")}'`).join(" ");
+  const cmd = `bun run '${script}' ${escapedArgs}; bash -c 'read -n1 -s -r'`;
+
+  try {
+    const paneId = execSync(
+      `tmux split-window ${splitDir} -l '${splitSize}' -P -F '#{pane_id}' "${cmd.replace(/"/g, '\\"')}"`,
+      { stdio: ["pipe", "pipe", "pipe"] },
+    ).toString().trim();
+    execSync(`tmux select-pane -t '${paneId}' -T 'kanban-board'`, { stdio: "ignore" });
+  } catch {
+    return false; // tmux split failed, fall through to inline rendering
+  }
+  return true;
+}
+
 function main(): void {
   const args = process.argv.slice(2);
   const command = args[0];
+
+  // If board command in non-TTY tmux context, reopen in a split pane and exit
+  if (maybeReopenInTmux(args)) return;
 
   let filePath = `${process.cwd()}/.claude/gtd/tasks.json`;
   let filterContext: string | undefined;
   let filterProject: string | undefined;
   let compact = false;
-  let widthOverride: number | undefined;
   let boardMode: "simple" | "regular" | "modern" = "regular";
 
   // Parse global options (non-positional)
@@ -911,26 +952,12 @@ function main(): void {
       case "--filter":  filterContext = args[++i]; break;
       case "--project": filterProject = args[++i]; break;
       case "--compact": compact = true; break;
-      case "--width":   widthOverride = parseInt(args[++i]); break;
       case "--mode": {
         const m = args[++i];
         if (m === "simple" || m === "regular" || m === "modern") boardMode = m;
         break;
       }
       default: positional.push(args[i]); break;
-    }
-  }
-
-  // Override terminal width if specified
-  if (widthOverride) {
-    // Override stdout.columns via Object.defineProperty so termW() picks it up
-    try {
-      Object.defineProperty(process.stdout, "columns", {
-        get: () => widthOverride,
-        configurable: true,
-      });
-    } catch {
-      process.env.COLUMNS = String(widthOverride);
     }
   }
 
@@ -998,8 +1025,7 @@ Options:
   --filter <@context>       Filter board by context
   --project <id>            Filter board by project ID
   --compact                 Compact board display
-  --mode simple|regular|modern  Board rendering mode (default: regular)
-  --width <n>               Override terminal width`);
+  --mode simple|regular|modern  Board rendering mode (default: regular)`);
       break;
   }
 }

--- a/plugins/stats/tests/db.test.ts
+++ b/plugins/stats/tests/db.test.ts
@@ -35,7 +35,9 @@ describe("db", () => {
     }
   });
 
-  function makeSession(id: string, project = "/test/project", date = "2026-03-26"): SessionMetrics {
+  const TODAY = new Date().toISOString().slice(0, 10);
+
+  function makeSession(id: string, project = "/test/project", date = TODAY): SessionMetrics {
     return {
       session_id: id,
       date,
@@ -48,14 +50,14 @@ describe("db", () => {
           duration_ms: 50,
           success: true,
           activity_category: "research",
-          timestamp: "2026-03-26T10:00:00.000Z",
+          timestamp: `${date}T10:00:00.000Z`,
         },
         {
           tool_name: "Write",
           duration_ms: 30,
           success: true,
           activity_category: "coding",
-          timestamp: "2026-03-26T10:01:00.000Z",
+          timestamp: `${date}T10:01:00.000Z`,
         },
       ],
       activity_counts: {
@@ -193,8 +195,8 @@ describe("db", () => {
 
   test("getSessionSummary returns aggregate stats", () => {
     const db = openDb(dbPath);
-    insertSession(db, makeSession("s1", "/test/project", "2026-03-26"));
-    insertSession(db, makeSession("s2", "/test/project", "2026-03-26"));
+    insertSession(db, makeSession("s1", "/test/project", TODAY));
+    insertSession(db, makeSession("s2", "/test/project", TODAY));
 
     const summary = getSessionSummary(db, 7, "/test/project");
     expect(summary.session_count).toBe(2);
@@ -228,7 +230,7 @@ describe("db", () => {
     insertToolCalls(db, metrics.tool_calls, "old-session");
 
     // Insert a recent session
-    const recent = makeSession("recent-session", "/test/project", "2026-03-26");
+    const recent = makeSession("recent-session", "/test/project", TODAY);
     insertSession(db, recent);
 
     const { deletedCount } = deleteOldSessions(db, 90);

--- a/plugins/stats/tests/integration.test.ts
+++ b/plugins/stats/tests/integration.test.ts
@@ -68,10 +68,14 @@ function makeTempDir(): string {
   return dir;
 }
 
+const TODAY = new Date().toISOString().slice(0, 10);
+const YESTERDAY = new Date(Date.now() - 86400000).toISOString().slice(0, 10);
+const TWO_DAYS_AGO = new Date(Date.now() - 2 * 86400000).toISOString().slice(0, 10);
+
 function makeSession(
   id: string,
   project = "/test/project",
-  date = "2026-03-26",
+  date = TODAY,
   overrides: Partial<SessionMetrics> = {}
 ): SessionMetrics {
   return {
@@ -113,7 +117,7 @@ function makeSessionRow(
 ): SessionRow {
   return {
     id,
-    date: "2026-03-26",
+    date: TODAY,
     project: "/test/project",
     duration_sec: 600,
     total_tool_calls: 10,
@@ -123,7 +127,7 @@ function makeSessionRow(
     testing_calls: 1,
     delegation_calls: 1,
     other_calls: 1,
-    created_at: "2026-03-26T10:00:00.000Z",
+    created_at: `${TODAY}T10:00:00.000Z`,
     ...overrides,
   };
 }
@@ -378,8 +382,8 @@ describe("Database: schema, CRUD, retention, queries", () => {
     const db = openDb(dbPath);
 
     // Insert 2 sessions with known tool counts
-    insertSession(db, makeSession("s1", "/test/project", "2026-03-26"));
-    insertSession(db, makeSession("s2", "/test/project", "2026-03-26"));
+    insertSession(db, makeSession("s1", "/test/project", TODAY));
+    insertSession(db, makeSession("s2", "/test/project", TODAY));
     insertToolCalls(db, makeSession("s1").tool_calls, "s1");
     insertToolCalls(db, makeSession("s2").tool_calls, "s2");
 
@@ -412,7 +416,7 @@ describe("Database: schema, CRUD, retention, queries", () => {
     // Old session (well beyond 90 days)
     insertSession(db, makeSession("old", "/test/project", "2024-01-01"));
     // Recent session
-    insertSession(db, makeSession("recent", "/test/project", "2026-03-26"));
+    insertSession(db, makeSession("recent", "/test/project", TODAY));
 
     const { deletedCount } = deleteOldSessions(db, 90);
 
@@ -443,7 +447,7 @@ describe("Database: schema, CRUD, retention, queries", () => {
 
   test("deleteOldSessions returns 0 when no sessions are old enough", () => {
     const db = openDb(dbPath);
-    insertSession(db, makeSession("recent", "/test/project", "2026-03-26"));
+    insertSession(db, makeSession("recent", "/test/project", TODAY));
 
     const { deletedCount } = deleteOldSessions(db, 90);
 
@@ -454,14 +458,14 @@ describe("Database: schema, CRUD, retention, queries", () => {
 
   test("getTopTools returns tools ranked by call count", () => {
     const db = openDb(dbPath);
-    insertSession(db, makeSession("s1", "/test/project", "2026-03-26"));
+    insertSession(db, makeSession("s1", "/test/project", TODAY));
 
     const calls: ToolCallRecord[] = [
-      { tool_name: "Read", duration_ms: 10, success: true, activity_category: "research", timestamp: "2026-03-26T10:00:00.000Z" },
-      { tool_name: "Read", duration_ms: 20, success: true, activity_category: "research", timestamp: "2026-03-26T10:01:00.000Z" },
-      { tool_name: "Read", duration_ms: 15, success: true, activity_category: "research", timestamp: "2026-03-26T10:02:00.000Z" },
-      { tool_name: "Write", duration_ms: 30, success: true, activity_category: "coding", timestamp: "2026-03-26T10:03:00.000Z" },
-      { tool_name: "Bash", duration_ms: 100, success: true, activity_category: "other", timestamp: "2026-03-26T10:04:00.000Z" },
+      { tool_name: "Read", duration_ms: 10, success: true, activity_category: "research", timestamp: `${TODAY}T10:00:00.000Z` },
+      { tool_name: "Read", duration_ms: 20, success: true, activity_category: "research", timestamp: `${TODAY}T10:01:00.000Z` },
+      { tool_name: "Read", duration_ms: 15, success: true, activity_category: "research", timestamp: `${TODAY}T10:02:00.000Z` },
+      { tool_name: "Write", duration_ms: 30, success: true, activity_category: "coding", timestamp: `${TODAY}T10:03:00.000Z` },
+      { tool_name: "Bash", duration_ms: 100, success: true, activity_category: "other", timestamp: `${TODAY}T10:04:00.000Z` },
     ];
     insertToolCalls(db, calls, "s1");
 
@@ -484,10 +488,10 @@ describe("Database: schema, CRUD, retention, queries", () => {
   test("getDurationTrend returns daily data in ASC date order", () => {
     const db = openDb(dbPath);
 
-    // Insert sessions on different dates
-    insertSession(db, makeSession("s1", "/test/project", "2026-03-24"));
-    insertSession(db, makeSession("s2", "/test/project", "2026-03-25"));
-    insertSession(db, makeSession("s3", "/test/project", "2026-03-26"));
+    // Insert sessions on different dates (all within the 14-day window)
+    insertSession(db, makeSession("s1", "/test/project", TWO_DAYS_AGO));
+    insertSession(db, makeSession("s2", "/test/project", YESTERDAY));
+    insertSession(db, makeSession("s3", "/test/project", TODAY));
 
     const trend = getDurationTrend(db, 14, "/test/project");
 

--- a/tools/claudeup-core/src/__tests__/integration/conventions-integration.test.ts
+++ b/tools/claudeup-core/src/__tests__/integration/conventions-integration.test.ts
@@ -32,7 +32,6 @@ import { tmpdir } from 'node:os';
 import {
   // Gitignore operations
   ensureGitignoreEntries,
-  removeGitignoreEntries,
   checkGitignoreEntries,
   // CLAUDE.md operations
   parseClaudeMdSections,

--- a/tools/claudeup-core/src/__tests__/unit/doctor.test.ts
+++ b/tools/claudeup-core/src/__tests__/unit/doctor.test.ts
@@ -10,7 +10,7 @@
  * with real plugin.json files. runDoctor is tested by mocking the registry.
  */
 
-import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { mkdtemp, rm, writeFile, readFile, mkdir } from 'node:fs/promises';
 import { existsSync } from 'node:fs';
 import { tmpdir } from 'node:os';

--- a/tools/claudeup-core/src/services/conventions-manager.ts
+++ b/tools/claudeup-core/src/services/conventions-manager.ts
@@ -14,7 +14,6 @@
  */
 
 import { readFile, writeFile, stat, rename, unlink, open } from 'node:fs/promises';
-import { existsSync } from 'node:fs';
 import { randomUUID } from 'node:crypto';
 import { dirname, basename, join, resolve } from 'node:path';
 import { homedir } from 'node:os';

--- a/tools/claudeup-core/src/services/doctor.ts
+++ b/tools/claudeup-core/src/services/doctor.ts
@@ -26,7 +26,7 @@ import {
   removeClaudeMdSection,
 } from './conventions-manager.js';
 import { parsePluginId } from '../utils/string-utils.js';
-import type { PluginConventions, InstalledPluginEntry } from '../types/index.js';
+import type { PluginConventions } from '../types/index.js';
 
 // ============================================================
 // TYPES

--- a/tools/table/index.ts
+++ b/tools/table/index.ts
@@ -14,6 +14,8 @@
  *   Output:     print
  */
 
+import { execSync } from "child_process";
+
 // ── ANSI helpers ─────────────────────────────────────────────────────────────
 
 export const S = {
@@ -54,11 +56,64 @@ export function fg(style: string, text: string): string {
 
 // ── Text utilities ────────────────────────────────────────────────────────────
 
-/** Terminal width. Checks stdout, COLUMNS env var, defaults to 80. */
+/**
+ * Terminal width detection chain.
+ *
+ * Tries, in order:
+ *   1. process.stdout.columns (works when stdout is a TTY)
+ *   2. $COLUMNS env var (set by some shells / wrappers)
+ *   3. tmux pane_width (most accurate when inside a tmux pane)
+ *   4. Parent process TTY via stty (works when our own stdout is piped)
+ *   5. Fallback to 120 (reasonable default for modern terminals)
+ *
+ * Every shell-out is wrapped in try/catch so failures fall through silently.
+ */
 export function termW(): number {
-  return process.stdout.columns
-    || (process.env.COLUMNS ? parseInt(process.env.COLUMNS) : 0)
-    || 80;
+  // 1. Direct stdout columns
+  if (process.stdout.columns && process.stdout.columns > 0) {
+    return process.stdout.columns;
+  }
+
+  // 2. $COLUMNS env var
+  const envCols = process.env.COLUMNS ? parseInt(process.env.COLUMNS, 10) : 0;
+  if (envCols > 0) return envCols;
+
+  // 3. tmux pane width (only when TMUX env is set)
+  if (process.env.TMUX) {
+    try {
+      const w = parseInt(
+        execSync("tmux display-message -p '#{pane_width}'", { stdio: ["pipe", "pipe", "pipe"] })
+          .toString()
+          .trim(),
+        10,
+      );
+      if (w > 0) return w;
+    } catch { /* not in tmux or tmux unavailable */ }
+  }
+
+  // 4. Parent process TTY via stty
+  try {
+    const ppid = process.ppid ?? process.env.PPID;
+    if (ppid) {
+      const ttyName = execSync(`ps -o tty= -p ${ppid}`, { stdio: ["pipe", "pipe", "pipe"] })
+        .toString()
+        .trim();
+      if (ttyName && ttyName !== "?" && ttyName !== "??") {
+        const devPath = ttyName.startsWith("/dev/") ? ttyName : `/dev/${ttyName}`;
+        const sttyOut = execSync(`stty size < ${devPath}`, {
+          stdio: ["pipe", "pipe", "pipe"],
+          shell: "/bin/sh",
+        })
+          .toString()
+          .trim();
+        const cols = parseInt(sttyOut.split(/\s+/)[1], 10);
+        if (cols > 0) return cols;
+      }
+    }
+  } catch { /* no parent TTY or stty failed */ }
+
+  // 5. Fallback
+  return 120;
 }
 
 /** Remove all ANSI escape codes from text. */


### PR DESCRIPTION
## Summary

Fixes CI runs 24065489776, 24063290384, 24029941408, 24029941414.

Two root causes addressed:

1. **TypeScript unused imports (TS6133/TS6196)** — removed unused imports in `tools/claudeup-core` that caused `tsc --noEmit` to fail under `noUnusedLocals`:
   - `conventions-integration.test.ts`: `removeGitignoreEntries` (never called)
   - `doctor.test.ts`: `vi` (never used)
   - `conventions-manager.ts`: `existsSync` (unused after refactor)
   - `doctor.ts`: `InstalledPluginEntry` type (parameter removed)

2. **Stale hardcoded test dates** — `plugins/stats` tests had a hardcoded date of `2026-03-26` that fell outside the 7/14-day query windows used by `getSessionSummary`, `getTopTools`, and `getDurationTrend`, causing those tests to return zero results and fail assertions.

## Fix

- Removed unused imports flagged by TS6133/TS6196 in `tools/claudeup-core`
- Replaced hardcoded `"2026-03-26"` with dynamic `TODAY`/`YESTERDAY`/`TWO_DAYS_AGO` constants in `plugins/stats/tests/db.test.ts` and `plugins/stats/tests/integration.test.ts` so the tests stay green regardless of when CI runs

## Note on base branch

`main` in this repo is a distribution-only orphan branch. This PR targets `fix/ci-type-errors-and-stale-test-date`, the source-code branch that CI workflows run against.