### PR TITLE
fix(marketplace): bump browser-use version 1.1.1 → 1.1.2 in marketplace.json

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -318,8 +318,8 @@
         "ref": "main",
         "sha": "af9911e626dd1406295b20c8e4d80f52ff3d8266"
       },
-      "description": "Full-platform browser automation for Claude Code. v1.1.0: Thin wrapper over built-in BrowserUseServer \u2014 63% less code. Fix TCC downloads_path, per-PID Chrome profiles, graceful shutdown. 19 MCP tools, 5 skills.",
-      "version": "1.1.1",
+      "description": "Full-platform browser automation for Claude Code. v1.1.2: Re-fix oneOf schema rejection (browser-use#4211) lost in v1.1.0 rewrite \u2014 sanitize upstream tool schemas to strip oneOf/allOf/anyOf rejected by Claude API. 19 MCP tools, 5 skills.",
+      "version": "1.1.2",
       "author": {
         "name": "Jack Rudenko",
         "email": "i@madappgang.com",


### PR DESCRIPTION
## What failed

CI run 24276607217 (`test (22)` job in `test-plugins.yml`) failed with:

```
FAIL src/__tests__/integration/marketplace-sync.test.ts
  > marketplace-sync integration > real marketplace validation
  > should have version sync between plugin.json and marketplace.json

AssertionError: expected [ Array(1) ] to deeply equal []

+ Array [
+   "Plugin browser-use: version mismatch - plugin.json has 1.1.2, marketplace.json has 1.1.1",
+ ]
```

## Root cause

`plugins/browser-use/plugin.json` was bumped to `v1.1.2` (re-fix for oneOf schema rejection), but `.claude-plugin/marketplace.json` was never updated — it still showed `"version": "1.1.1"`.

The `marketplace-sync` integration test catches exactly this class of drift.

## Fix

| File | Change |
|------|--------|
| `.claude-plugin/marketplace.json` | `browser-use` version `1.1.1` → `1.1.2` |
| `.claude-plugin/marketplace.json` | description updated to match `plugin.json` (v1.1.2 changelog) |

## Verification

All 447 tests pass locally (355 unit + 92 integration) on Node 22:

```
Test Files  19 passed (19)
     Tests  447 passed (447)
```

## Context

This PR is stacked on #24 (`fix/ci-24065489776-ts-and-dates`), which fixes the original TypeScript unused-import failures and re-enables CI triggers. This PR fixes the remaining test failure that appeared once CI was actually running again.

https://claude.ai/code/session_013HXzUfAgz27nNfj3RsGNGf