### PR TITLE
fix(ci): consolidated — TS imports, stale dates, browser-use version, unrestricted triggers

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -54,7 +54,7 @@
         "ref": "main",
         "sha": "af9911e626dd1406295b20c8e4d80f52ff3d8266"
       },
-      "description": "Multi-model collaboration, orchestration, and workflow patterns. v3.1.2: Fix internal model leaked to claudish \u2014 filter sentinel before external dispatch.",
+      "description": "Multi-model collaboration, orchestration, and workflow patterns. v3.1.2: Fix internal model leaked to claudish — filter sentinel before external dispatch.",
       "version": "3.1.2",
       "author": {
         "name": "Jack Rudenko",
@@ -89,7 +89,7 @@
         "ref": "main",
         "sha": "af9911e626dd1406295b20c8e4d80f52ff3d8266"
       },
-      "description": "Create, implement, and review Claude Code agents and commands with multi-model validation, LLM performance tracking, and session-based artifact isolation. v1.6.1: Fix manifest schema \u2014 agents paths, hooks format.",
+      "description": "Create, implement, and review Claude Code agents and commands with multi-model validation, LLM performance tracking, and session-based artifact isolation. v1.6.1: Fix manifest schema — agents paths, hooks format.",
       "version": "1.6.1",
       "author": {
         "name": "Jack Rudenko",
@@ -210,7 +210,7 @@
         "ref": "main",
         "sha": "af9911e626dd1406295b20c8e4d80f52ff3d8266"
       },
-      "description": "Context-Driven Development workflow inspired by Gemini Conductor. v2.1.3: Fix manifest schema \u2014 commands paths, add skills registration.",
+      "description": "Context-Driven Development workflow inspired by Gemini Conductor. v2.1.3: Fix manifest schema — commands paths, add skills registration.",
       "version": "2.1.3",
       "author": {
         "name": "Jack Rudenko",
@@ -241,7 +241,7 @@
         "ref": "main",
         "sha": "af9911e626dd1406295b20c8e4d80f52ff3d8266"
       },
-      "description": "Universal development assistant. v2.6.0: self-learning Stop hook \u2014 automated session learning with LLM classifier, background daemon, /dev:learn --apply/--prune.",
+      "description": "Universal development assistant. v2.6.0: self-learning Stop hook — automated session learning with LLM classifier, background daemon, /dev:learn --apply/--prune.",
       "version": "2.7.0",
       "author": {
         "name": "Jack Rudenko",
@@ -290,7 +290,7 @@
         "ref": "main",
         "sha": "af9911e626dd1406295b20c8e4d80f52ff3d8266"
       },
-      "description": "Adaptive statusline \u2014 always-visible bars, background highlights for critical states, provider-aware model display, vim mode, diff stats, compaction count, memory usage. v2.1.0: Prominent reset countdowns when rate-limited, process memory display.",
+      "description": "Adaptive statusline — always-visible bars, background highlights for critical states, provider-aware model display, vim mode, diff stats, compaction count, memory usage. v2.1.0: Prominent reset countdowns when rate-limited, process memory display.",
       "version": "2.1.0",
       "author": {
         "name": "Jack Rudenko",
@@ -318,8 +318,8 @@
         "ref": "main",
         "sha": "af9911e626dd1406295b20c8e4d80f52ff3d8266"
       },
-      "description": "Full-platform browser automation for Claude Code. v1.1.0: Thin wrapper over built-in BrowserUseServer \u2014 63% less code. Fix TCC downloads_path, per-PID Chrome profiles, graceful shutdown. 19 MCP tools, 5 skills.",
-      "version": "1.1.1",
+      "description": "Full-platform browser automation for Claude Code. v1.1.2: Re-fix oneOf schema rejection (browser-use#4211) lost in v1.1.0 rewrite — sanitize upstream tool schemas to strip oneOf/allOf/anyOf rejected by Claude API. 19 MCP tools, 5 skills.",
+      "version": "1.1.2",
       "author": {
         "name": "Jack Rudenko",
         "email": "i@madappgang.com",
@@ -382,7 +382,7 @@
         "ref": "main",
         "sha": "af9911e626dd1406295b20c8e4d80f52ff3d8266"
       },
-      "description": "Interactive terminal integration for Claude Code. v4.0.0: agentic-first rewrite \u2014 single Go tmux-mcp binary replaces ht-mcp + npm tmux-mcp. New agentic tools (start-and-watch, watch-pane, run-in-repl, pane-state) eliminate all polling loops. 5 skills, 9 commands, 1 agent.",
+      "description": "Interactive terminal integration for Claude Code. v4.0.0: agentic-first rewrite — single Go tmux-mcp binary replaces ht-mcp + npm tmux-mcp. New agentic tools (start-and-watch, watch-pane, run-in-repl, pane-state) eliminate all polling loops. 5 skills, 9 commands, 1 agent.",
       "version": "4.0.2",
       "author": {
         "name": "Jack Rudenko",
@@ -442,7 +442,7 @@
         "ref": "main",
         "sha": "af9911e626dd1406295b20c8e4d80f52ff3d8266"
       },
-      "description": "Kanban board view for task management. v1.2.0: Word-wrapped titles, full-width boards, even column distribution. Visual board with 5 columns, task dependencies (cycle-safe), priority indicators, WIP limits. Shares tasks.json with GTD plugin \u2014 works standalone or alongside GTD.",
+      "description": "Kanban board view for task management. v1.2.0: Word-wrapped titles, full-width boards, even column distribution. Visual board with 5 columns, task dependencies (cycle-safe), priority indicators, WIP limits. Shares tasks.json with GTD plugin — works standalone or alongside GTD.",
       "version": "1.2.0",
       "author": {
         "name": "Jack Rudenko",

--- a/.github/workflows/test-plugins.yml
+++ b/.github/workflows/test-plugins.yml
@@ -2,7 +2,7 @@ name: Test Plugins
 
 on:
   push:
-    branches: [main]
+    branches: [main, fix/ci-type-errors-and-stale-test-date]
     paths:
       - 'tools/claudeup-core/**'
       - 'tools/pnpm-lock.yaml'
@@ -14,7 +14,7 @@ on:
       - 'scripts/sync-shared-deps.sh'
       - '.github/workflows/test-plugins.yml'
   pull_request:
-    branches: [main]
+    branches: [main, fix/ci-type-errors-and-stale-test-date]
     paths:
       - 'tools/claudeup-core/**'
       - 'tools/pnpm-lock.yaml'

--- a/.github/workflows/test-plugins.yml
+++ b/.github/workflows/test-plugins.yml
@@ -2,7 +2,6 @@ name: Test Plugins
 
 on:
   push:
-    branches: [main, fix/ci-type-errors-and-stale-test-date]
     paths:
       - 'tools/claudeup-core/**'
       - 'tools/pnpm-lock.yaml'
@@ -14,7 +13,6 @@ on:
       - 'scripts/sync-shared-deps.sh'
       - '.github/workflows/test-plugins.yml'
   pull_request:
-    branches: [main, fix/ci-type-errors-and-stale-test-date]
     paths:
       - 'tools/claudeup-core/**'
       - 'tools/pnpm-lock.yaml'

--- a/.github/workflows/test-stats.yml
+++ b/.github/workflows/test-stats.yml
@@ -2,12 +2,10 @@ name: Test Stats Plugin
 
 on:
   push:
-    branches: [main, fix/ci-type-errors-and-stale-test-date]
     paths:
       - 'plugins/stats/**'
       - '.github/workflows/test-stats.yml'
   pull_request:
-    branches: [main, fix/ci-type-errors-and-stale-test-date]
     paths:
       - 'plugins/stats/**'
       - '.github/workflows/test-stats.yml'

--- a/.github/workflows/test-stats.yml
+++ b/.github/workflows/test-stats.yml
@@ -2,12 +2,12 @@ name: Test Stats Plugin
 
 on:
   push:
-    branches: [main]
+    branches: [main, fix/ci-type-errors-and-stale-test-date]
     paths:
       - 'plugins/stats/**'
       - '.github/workflows/test-stats.yml'
   pull_request:
-    branches: [main]
+    branches: [main, fix/ci-type-errors-and-stale-test-date]
     paths:
       - 'plugins/stats/**'
       - '.github/workflows/test-stats.yml'

--- a/plugins/stats/tests/db.test.ts
+++ b/plugins/stats/tests/db.test.ts
@@ -35,7 +35,9 @@ describe("db", () => {
     }
   });
 
-  function makeSession(id: string, project = "/test/project", date = "2026-03-26"): SessionMetrics {
+  const TODAY = new Date().toISOString().slice(0, 10);
+
+  function makeSession(id: string, project = "/test/project", date = TODAY): SessionMetrics {
     return {
       session_id: id,
       date,
@@ -48,14 +50,14 @@ describe("db", () => {
           duration_ms: 50,
           success: true,
           activity_category: "research",
-          timestamp: "2026-03-26T10:00:00.000Z",
+          timestamp: `${date}T10:00:00.000Z`,
         },
         {
           tool_name: "Write",
           duration_ms: 30,
           success: true,
           activity_category: "coding",
-          timestamp: "2026-03-26T10:01:00.000Z",
+          timestamp: `${date}T10:01:00.000Z`,
         },
       ],
       activity_counts: {
@@ -193,9 +195,8 @@ describe("db", () => {
 
   test("getSessionSummary returns aggregate stats", () => {
     const db = openDb(dbPath);
-    const today = new Date().toISOString().slice(0, 10);
-    insertSession(db, makeSession("s1", "/test/project", today));
-    insertSession(db, makeSession("s2", "/test/project", today));
+    insertSession(db, makeSession("s1", "/test/project", TODAY));
+    insertSession(db, makeSession("s2", "/test/project", TODAY));
 
     const summary = getSessionSummary(db, 7, "/test/project");
     expect(summary.session_count).toBe(2);
@@ -229,7 +230,7 @@ describe("db", () => {
     insertToolCalls(db, metrics.tool_calls, "old-session");
 
     // Insert a recent session
-    const recent = makeSession("recent-session", "/test/project", "2026-03-26");
+    const recent = makeSession("recent-session", "/test/project", TODAY);
     insertSession(db, recent);
 
     const { deletedCount } = deleteOldSessions(db, 90);

--- a/plugins/stats/tests/integration.test.ts
+++ b/plugins/stats/tests/integration.test.ts
@@ -68,10 +68,14 @@ function makeTempDir(): string {
   return dir;
 }
 
+const TODAY = new Date().toISOString().slice(0, 10);
+const YESTERDAY = new Date(Date.now() - 86400000).toISOString().slice(0, 10);
+const TWO_DAYS_AGO = new Date(Date.now() - 2 * 86400000).toISOString().slice(0, 10);
+
 function makeSession(
   id: string,
   project = "/test/project",
-  date = "2026-03-26",
+  date = TODAY,
   overrides: Partial<SessionMetrics> = {}
 ): SessionMetrics {
   return {
@@ -113,7 +117,7 @@ function makeSessionRow(
 ): SessionRow {
   return {
     id,
-    date: "2026-03-26",
+    date: TODAY,
     project: "/test/project",
     duration_sec: 600,
     total_tool_calls: 10,
@@ -123,7 +127,7 @@ function makeSessionRow(
     testing_calls: 1,
     delegation_calls: 1,
     other_calls: 1,
-    created_at: "2026-03-26T10:00:00.000Z",
+    created_at: `${TODAY}T10:00:00.000Z`,
     ...overrides,
   };
 }
@@ -378,8 +382,8 @@ describe("Database: schema, CRUD, retention, queries", () => {
     const db = openDb(dbPath);
 
     // Insert 2 sessions with known tool counts
-    insertSession(db, makeSession("s1", "/test/project", "2026-03-26"));
-    insertSession(db, makeSession("s2", "/test/project", "2026-03-26"));
+    insertSession(db, makeSession("s1", "/test/project", TODAY));
+    insertSession(db, makeSession("s2", "/test/project", TODAY));
     insertToolCalls(db, makeSession("s1").tool_calls, "s1");
     insertToolCalls(db, makeSession("s2").tool_calls, "s2");
 
@@ -412,7 +416,7 @@ describe("Database: schema, CRUD, retention, queries", () => {
     // Old session (well beyond 90 days)
     insertSession(db, makeSession("old", "/test/project", "2024-01-01"));
     // Recent session
-    insertSession(db, makeSession("recent", "/test/project", "2026-03-26"));
+    insertSession(db, makeSession("recent", "/test/project", TODAY));
 
     const { deletedCount } = deleteOldSessions(db, 90);
 
@@ -443,7 +447,7 @@ describe("Database: schema, CRUD, retention, queries", () => {
 
   test("deleteOldSessions returns 0 when no sessions are old enough", () => {
     const db = openDb(dbPath);
-    insertSession(db, makeSession("recent", "/test/project", "2026-03-26"));
+    insertSession(db, makeSession("recent", "/test/project", TODAY));
 
     const { deletedCount } = deleteOldSessions(db, 90);
 
@@ -454,14 +458,14 @@ describe("Database: schema, CRUD, retention, queries", () => {
 
   test("getTopTools returns tools ranked by call count", () => {
     const db = openDb(dbPath);
-    insertSession(db, makeSession("s1", "/test/project", "2026-03-26"));
+    insertSession(db, makeSession("s1", "/test/project", TODAY));
 
     const calls: ToolCallRecord[] = [
-      { tool_name: "Read", duration_ms: 10, success: true, activity_category: "research", timestamp: "2026-03-26T10:00:00.000Z" },
-      { tool_name: "Read", duration_ms: 20, success: true, activity_category: "research", timestamp: "2026-03-26T10:01:00.000Z" },
-      { tool_name: "Read", duration_ms: 15, success: true, activity_category: "research", timestamp: "2026-03-26T10:02:00.000Z" },
-      { tool_name: "Write", duration_ms: 30, success: true, activity_category: "coding", timestamp: "2026-03-26T10:03:00.000Z" },
-      { tool_name: "Bash", duration_ms: 100, success: true, activity_category: "other", timestamp: "2026-03-26T10:04:00.000Z" },
+      { tool_name: "Read", duration_ms: 10, success: true, activity_category: "research", timestamp: `${TODAY}T10:00:00.000Z` },
+      { tool_name: "Read", duration_ms: 20, success: true, activity_category: "research", timestamp: `${TODAY}T10:01:00.000Z` },
+      { tool_name: "Read", duration_ms: 15, success: true, activity_category: "research", timestamp: `${TODAY}T10:02:00.000Z` },
+      { tool_name: "Write", duration_ms: 30, success: true, activity_category: "coding", timestamp: `${TODAY}T10:03:00.000Z` },
+      { tool_name: "Bash", duration_ms: 100, success: true, activity_category: "other", timestamp: `${TODAY}T10:04:00.000Z` },
     ];
     insertToolCalls(db, calls, "s1");
 
@@ -484,10 +488,10 @@ describe("Database: schema, CRUD, retention, queries", () => {
   test("getDurationTrend returns daily data in ASC date order", () => {
     const db = openDb(dbPath);
 
-    // Insert sessions on different dates
-    insertSession(db, makeSession("s1", "/test/project", "2026-03-24"));
-    insertSession(db, makeSession("s2", "/test/project", "2026-03-25"));
-    insertSession(db, makeSession("s3", "/test/project", "2026-03-26"));
+    // Insert sessions on different dates (all within the 14-day window)
+    insertSession(db, makeSession("s1", "/test/project", TWO_DAYS_AGO));
+    insertSession(db, makeSession("s2", "/test/project", YESTERDAY));
+    insertSession(db, makeSession("s3", "/test/project", TODAY));
 
     const trend = getDurationTrend(db, 14, "/test/project");
 

--- a/tools/claudeup-core/src/__tests__/integration/conventions-integration.test.ts
+++ b/tools/claudeup-core/src/__tests__/integration/conventions-integration.test.ts
@@ -32,7 +32,6 @@ import { tmpdir } from 'node:os';
 import {
   // Gitignore operations
   ensureGitignoreEntries,
-  removeGitignoreEntries,
   checkGitignoreEntries,
   // CLAUDE.md operations
   parseClaudeMdSections,

--- a/tools/claudeup-core/src/__tests__/unit/doctor.test.ts
+++ b/tools/claudeup-core/src/__tests__/unit/doctor.test.ts
@@ -10,7 +10,7 @@
  * with real plugin.json files. runDoctor is tested by mocking the registry.
  */
 
-import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { mkdtemp, rm, writeFile, readFile, mkdir } from 'node:fs/promises';
 import { existsSync } from 'node:fs';
 import { tmpdir } from 'node:os';

--- a/tools/claudeup-core/src/services/conventions-manager.ts
+++ b/tools/claudeup-core/src/services/conventions-manager.ts
@@ -14,7 +14,6 @@
  */
 
 import { readFile, writeFile, stat, rename, unlink, open } from 'node:fs/promises';
-import { existsSync } from 'node:fs';
 import { randomUUID } from 'node:crypto';
 import { dirname, basename, join, resolve } from 'node:path';
 import { homedir } from 'node:os';


### PR DESCRIPTION
## What this PR fixes

This consolidates all outstanding CI failures into a single, self-contained PR that is based on top of **PR #24** (the comprehensive code fix) and adds the final workflow-trigger broadening from **PR #32**.

### Failed runs addressed

| Run ID | Workflow | Branch | Failure |
|--------|----------|--------|---------|
| 24065489776 | Test Plugins | main | `tsc --noEmit` — 3 unused TS imports |
| 24063290384 | Test Plugins | main | shared-deps out of sync + type check |
| 24298790072 | Test Plugins | fix/ci-workflow-trigger-broadening | type check (inherited from base) |
| 24298790076 | Test Stats Plugin | fix/ci-workflow-trigger-broadening | stale date in time-windowed queries |
| 24298782547 | Test Stats Plugin | fix/ci-workflow-trigger-broadening | stale date in time-windowed queries |
| 24298781727 | Test Plugins | fix/ci-workflow-trigger-broadening | type check (inherited from base) |
| 24276607217 | Test Plugins | fix/ci-24065489776-ts-and-dates | browser-use version mismatch |
| 24276583408 | Test Stats Plugin | fix/ci-type-errors-and-stale-test-date | stale date |
| 24276582786 | Test Plugins | fix/ci-type-errors-and-stale-test-date | type check |
| 24040412326 | Test Stats Plugin | fix/ci-type-errors-and-stale-test-date | stale date |

---

## Root causes & fixes

### 1. Unused TypeScript imports (TS6133) — inherited from PR #24
`tsc --noEmit` fails under `noUnusedLocals` for three imports left behind after refactors:

| File | Unused import |
|------|--------------|
| `tools/claudeup-core/src/__tests__/integration/conventions-integration.test.ts` | `removeGitignoreEntries` |
| `tools/claudeup-core/src/__tests__/unit/doctor.test.ts` | `vi` |
| `tools/claudeup-core/src/services/conventions-manager.ts` | `existsSync` |

**Fix:** removed all three (carried in from PR #24 head).

### 2. Stale hardcoded test dates — inherited from PR #24
`plugins/stats/tests/db.test.ts` and `integration.test.ts` used `"2026-03-26"` which is now 17 days old — outside the 7-day and 14-day rolling query windows used by `getSessionSummary`, `getTopTools`, and `getDurationTrend`. Those tests assert `length > 0` / specific counts and return zero rows.

**Fix:** dynamic `TODAY`/`YESTERDAY`/`TWO_DAYS_AGO` constants (carried in from PR #24 head).

### 3. browser-use version mismatch — inherited from PR #24
`plugins/browser-use/plugin.json` was bumped to `v1.1.2` but `.claude-plugin/marketplace.json` was left at `v1.1.1`. The `marketplace-sync` integration test catches exactly this drift.

**Fix:** `marketplace.json` bumped to `1.1.2` (carried in from PR #24 head).

### 4. Hardcoded branch filters in workflow triggers — new commit in this PR
Both `test-plugins.yml` and `test-stats.yml` had a `branches` allowlist:

```yaml
push:
  branches: [main, fix/ci-type-errors-and-stale-test-date]
pull_request:
  branches: [main, fix/ci-type-errors-and-stale-test-date]
```

Any branch not in that list (every new `fix/*` or `feat/*` branch) was invisible to CI — pushes and PRs only triggered GitGuardian. This is why PRs #22, #23, #28, #31, and #32 all lacked test CI runs.

**Fix:** removed the `branches` key entirely from both triggers in both files. Path filters already limit CI to relevant file changes, so there is no noise increase.

---

## Why PR #32 was still failing

PR #32 (`fix/ci-workflow-trigger-broadening`) only changed the workflow YAML — it was stacked directly on `fix/ci-type-errors-and-stale-test-date`, which still had the broken TS imports and stale dates. CI ran (the trigger fix worked), but the tests themselves failed.

This PR is branched from **PR #24's head** (`fix/ci-24065489776-ts-and-dates`) so all code-level fixes are already present. The single new commit removes the branch filters.

## Supersedes
- PR #32 (`fix/ci-workflow-trigger-broadening`) — same trigger fix but with all code fixes included
- PRs #22, #23 — TS + date subset (superseded by PR #24 which this is based on)
- PR #28 — browser-use version subset

## Does NOT supersede
- PR #24 (`fix/ci-24065489776-ts-and-dates`) — this PR is based directly on its head and includes all its changes plus the trigger broadening. If #24 is merged first, this PR's diff will shrink to just the two workflow-file changes.