### PR TITLE
fix(ci): complete all-fixes branch — rolling stats dates in integration.test.ts + browser-use 1.1.2

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -318,8 +318,8 @@
         "ref": "main",
         "sha": "af9911e626dd1406295b20c8e4d80f52ff3d8266"
       },
-      "description": "Full-platform browser automation for Claude Code. v1.1.0: Thin wrapper over built-in BrowserUseServer \u2014 63% less code. Fix TCC downloads_path, per-PID Chrome profiles, graceful shutdown. 19 MCP tools, 5 skills.",
-      "version": "1.1.1",
+      "description": "Full-platform browser automation for Claude Code. v1.1.2: Re-fix oneOf schema rejection (browser-use#4211) lost in v1.1.0 rewrite — sanitize upstream tool schemas to strip oneOf/allOf/anyOf rejected by Claude API. 19 MCP tools, 5 skills.",
+      "version": "1.1.2",
       "author": {
         "name": "Jack Rudenko",
         "email": "i@madappgang.com",

--- a/.github/workflows/test-plugins.yml
+++ b/.github/workflows/test-plugins.yml
@@ -2,7 +2,6 @@ name: Test Plugins
 
 on:
   push:
-    branches: [main, fix/ci-type-errors-and-stale-test-date]
     paths:
       - 'tools/claudeup-core/**'
       - 'tools/pnpm-lock.yaml'
@@ -14,7 +13,6 @@ on:
       - 'scripts/sync-shared-deps.sh'
       - '.github/workflows/test-plugins.yml'
   pull_request:
-    branches: [main, fix/ci-type-errors-and-stale-test-date]
     paths:
       - 'tools/claudeup-core/**'
       - 'tools/pnpm-lock.yaml'

--- a/.github/workflows/test-stats.yml
+++ b/.github/workflows/test-stats.yml
@@ -2,12 +2,10 @@ name: Test Stats Plugin
 
 on:
   push:
-    branches: [main, fix/ci-type-errors-and-stale-test-date]
     paths:
       - 'plugins/stats/**'
       - '.github/workflows/test-stats.yml'
   pull_request:
-    branches: [main, fix/ci-type-errors-and-stale-test-date]
     paths:
       - 'plugins/stats/**'
       - '.github/workflows/test-stats.yml'

--- a/plugins/stats/tests/db.test.ts
+++ b/plugins/stats/tests/db.test.ts
@@ -35,7 +35,9 @@ describe("db", () => {
     }
   });
 
-  function makeSession(id: string, project = "/test/project", date = "2026-03-26"): SessionMetrics {
+  const TODAY = new Date().toISOString().slice(0, 10);
+
+  function makeSession(id: string, project = "/test/project", date = TODAY): SessionMetrics {
     return {
       session_id: id,
       date,
@@ -48,14 +50,14 @@ describe("db", () => {
           duration_ms: 50,
           success: true,
           activity_category: "research",
-          timestamp: "2026-03-26T10:00:00.000Z",
+          timestamp: `${date}T10:00:00.000Z`,
         },
         {
           tool_name: "Write",
           duration_ms: 30,
           success: true,
           activity_category: "coding",
-          timestamp: "2026-03-26T10:01:00.000Z",
+          timestamp: `${date}T10:01:00.000Z`,
         },
       ],
       activity_counts: {
@@ -193,9 +195,8 @@ describe("db", () => {
 
   test("getSessionSummary returns aggregate stats", () => {
     const db = openDb(dbPath);
-    const today = new Date().toISOString().slice(0, 10);
-    insertSession(db, makeSession("s1", "/test/project", today));
-    insertSession(db, makeSession("s2", "/test/project", today));
+    insertSession(db, makeSession("s1", "/test/project", TODAY));
+    insertSession(db, makeSession("s2", "/test/project", TODAY));
 
     const summary = getSessionSummary(db, 7, "/test/project");
     expect(summary.session_count).toBe(2);
@@ -229,7 +230,7 @@ describe("db", () => {
     insertToolCalls(db, metrics.tool_calls, "old-session");
 
     // Insert a recent session
-    const recent = makeSession("recent-session", "/test/project", "2026-03-26");
+    const recent = makeSession("recent-session", "/test/project", TODAY);
     insertSession(db, recent);
 
     const { deletedCount } = deleteOldSessions(db, 90);

--- a/plugins/stats/tests/integration.test.ts
+++ b/plugins/stats/tests/integration.test.ts
@@ -62,6 +62,10 @@ import type {
 // Shared test helpers
 // ──────────────────────────────────────────────────────────────────────────────
 
+const TODAY = new Date().toISOString().slice(0, 10);
+const YESTERDAY = new Date(Date.now() - 86_400_000).toISOString().slice(0, 10);
+const TWO_DAYS_AGO = new Date(Date.now() - 2 * 86_400_000).toISOString().slice(0, 10);
+
 function makeTempDir(): string {
   const dir = join(tmpdir(), `stats-integ-${randomUUID()}`);
   mkdirSync(dir, { recursive: true });
@@ -71,7 +75,7 @@ function makeTempDir(): string {
 function makeSession(
   id: string,
   project = "/test/project",
-  date = "2026-03-26",
+  date = TODAY,
   overrides: Partial<SessionMetrics> = {}
 ): SessionMetrics {
   return {
@@ -378,8 +382,8 @@ describe("Database: schema, CRUD, retention, queries", () => {
     const db = openDb(dbPath);
 
     // Insert 2 sessions with known tool counts
-    insertSession(db, makeSession("s1", "/test/project", "2026-03-26"));
-    insertSession(db, makeSession("s2", "/test/project", "2026-03-26"));
+    insertSession(db, makeSession("s1", "/test/project", TODAY));
+    insertSession(db, makeSession("s2", "/test/project", TODAY));
     insertToolCalls(db, makeSession("s1").tool_calls, "s1");
     insertToolCalls(db, makeSession("s2").tool_calls, "s2");
 
@@ -412,7 +416,7 @@ describe("Database: schema, CRUD, retention, queries", () => {
     // Old session (well beyond 90 days)
     insertSession(db, makeSession("old", "/test/project", "2024-01-01"));
     // Recent session
-    insertSession(db, makeSession("recent", "/test/project", "2026-03-26"));
+    insertSession(db, makeSession("recent", "/test/project", TODAY));
 
     const { deletedCount } = deleteOldSessions(db, 90);
 
@@ -443,7 +447,7 @@ describe("Database: schema, CRUD, retention, queries", () => {
 
   test("deleteOldSessions returns 0 when no sessions are old enough", () => {
     const db = openDb(dbPath);
-    insertSession(db, makeSession("recent", "/test/project", "2026-03-26"));
+    insertSession(db, makeSession("recent", "/test/project", TODAY));
 
     const { deletedCount } = deleteOldSessions(db, 90);
 
@@ -454,14 +458,14 @@ describe("Database: schema, CRUD, retention, queries", () => {
 
   test("getTopTools returns tools ranked by call count", () => {
     const db = openDb(dbPath);
-    insertSession(db, makeSession("s1", "/test/project", "2026-03-26"));
+    insertSession(db, makeSession("s1", "/test/project", TODAY));
 
     const calls: ToolCallRecord[] = [
-      { tool_name: "Read", duration_ms: 10, success: true, activity_category: "research", timestamp: "2026-03-26T10:00:00.000Z" },
-      { tool_name: "Read", duration_ms: 20, success: true, activity_category: "research", timestamp: "2026-03-26T10:01:00.000Z" },
-      { tool_name: "Read", duration_ms: 15, success: true, activity_category: "research", timestamp: "2026-03-26T10:02:00.000Z" },
-      { tool_name: "Write", duration_ms: 30, success: true, activity_category: "coding", timestamp: "2026-03-26T10:03:00.000Z" },
-      { tool_name: "Bash", duration_ms: 100, success: true, activity_category: "other", timestamp: "2026-03-26T10:04:00.000Z" },
+      { tool_name: "Read", duration_ms: 10, success: true, activity_category: "research", timestamp: `${TODAY}T10:00:00.000Z` },
+      { tool_name: "Read", duration_ms: 20, success: true, activity_category: "research", timestamp: `${TODAY}T10:01:00.000Z` },
+      { tool_name: "Read", duration_ms: 15, success: true, activity_category: "research", timestamp: `${TODAY}T10:02:00.000Z` },
+      { tool_name: "Write", duration_ms: 30, success: true, activity_category: "coding", timestamp: `${TODAY}T10:03:00.000Z` },
+      { tool_name: "Bash", duration_ms: 100, success: true, activity_category: "other", timestamp: `${TODAY}T10:04:00.000Z` },
     ];
     insertToolCalls(db, calls, "s1");
 
@@ -484,10 +488,10 @@ describe("Database: schema, CRUD, retention, queries", () => {
   test("getDurationTrend returns daily data in ASC date order", () => {
     const db = openDb(dbPath);
 
-    // Insert sessions on different dates
-    insertSession(db, makeSession("s1", "/test/project", "2026-03-24"));
-    insertSession(db, makeSession("s2", "/test/project", "2026-03-25"));
-    insertSession(db, makeSession("s3", "/test/project", "2026-03-26"));
+    // Insert sessions on different dates (all within 14-day window)
+    insertSession(db, makeSession("s1", "/test/project", TWO_DAYS_AGO));
+    insertSession(db, makeSession("s2", "/test/project", YESTERDAY));
+    insertSession(db, makeSession("s3", "/test/project", TODAY));
 
     const trend = getDurationTrend(db, 14, "/test/project");
 

--- a/tools/claudeup-core/src/__tests__/integration/conventions-integration.test.ts
+++ b/tools/claudeup-core/src/__tests__/integration/conventions-integration.test.ts
@@ -32,7 +32,6 @@ import { tmpdir } from 'node:os';
 import {
   // Gitignore operations
   ensureGitignoreEntries,
-  removeGitignoreEntries,
   checkGitignoreEntries,
   // CLAUDE.md operations
   parseClaudeMdSections,

--- a/tools/claudeup-core/src/__tests__/unit/doctor.test.ts
+++ b/tools/claudeup-core/src/__tests__/unit/doctor.test.ts
@@ -10,7 +10,7 @@
  * with real plugin.json files. runDoctor is tested by mocking the registry.
  */
 
-import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { mkdtemp, rm, writeFile, readFile, mkdir } from 'node:fs/promises';
 import { existsSync } from 'node:fs';
 import { tmpdir } from 'node:os';

--- a/tools/claudeup-core/src/services/conventions-manager.ts
+++ b/tools/claudeup-core/src/services/conventions-manager.ts
@@ -14,7 +14,6 @@
  */
 
 import { readFile, writeFile, stat, rename, unlink, open } from 'node:fs/promises';
-import { existsSync } from 'node:fs';
 import { randomUUID } from 'node:crypto';
 import { dirname, basename, join, resolve } from 'node:path';
 import { homedir } from 'node:os';


### PR DESCRIPTION
## What was still failing on `fix/ci-all-fixes-final`

Two root causes were not addressed in prior commits to this branch, causing runs 24307096245 (`Test Stats Plugin`) and 24307096246 (`Test Plugins`) to continue failing after today's push:

### 1. `plugins/stats/tests/integration.test.ts` — stale hardcoded dates (Test Stats Plugin)

The previous commit `fix(stats/db.test): use rolling TODAY date` only fixed `db.test.ts`. The companion file `integration.test.ts` still had `date = "2026-03-26"` as the default in `makeSession()`. Three tests use time-windowed DB queries against those stale dates:

| Test | Query window | Hardcoded date | Days old | Result |
|------|-------------|---------------|----------|--------|
| `getSessionSummary returns correct averages and totals` | 7 days | `2026-03-26` | 17 | 0 rows → assertion fails |
| `getTopTools returns tools ranked by call count` | 7 days | `2026-03-26` | 17 | 0 rows → assertion fails |
| `getDurationTrend returns daily data in ASC date order` | 14 days | `2026-03-24/25/26` | 17–19 | 0 rows → assertion fails |

**Fix:** Added module-level `TODAY`, `YESTERDAY`, `TWO_DAYS_AGO` constants (same pattern already applied in `db.test.ts`). Updated all time-windowed test cases to use these.

### 2. `.claude-plugin/marketplace.json` — browser-use still at `1.1.1` (Test Plugins)

Commit `b6de79a` message claimed to bump browser-use from `1.1.1` → `1.1.2` in `marketplace.json`, but inspecting the file shows the version was never actually changed. `plugins/browser-use/plugin.json` is at `1.1.2`, so the `marketplace-sync` integration test keeps failing:

```
AssertionError: Plugin browser-use: version mismatch - plugin.json has 1.1.2, marketplace.json has 1.1.1
```

**Fix:** Bumped `browser-use` version to `1.1.2` and updated description to match `plugin.json`.

## Files changed

| File | Change |
|------|--------|
| `plugins/stats/tests/integration.test.ts` | Add `TODAY`/`YESTERDAY`/`TWO_DAYS_AGO`; use them in 4 time-windowed tests |
| `.claude-plugin/marketplace.json` | `browser-use` version `1.1.1` → `1.1.2`, description updated |

## Relationship to other open PRs

- **PR #33** (`fix/ci-consolidated`) covers the same set of issues but on a different branch. If #33 is merged first, this PR's diff will shrink to just these two remaining fixes.
- **PR #24** (`fix/ci-24065489776-ts-and-dates`) — this branch builds on top of its base.

https://claude.ai/code/session_01661kBw9mduVyAKpwLBnHjV