### PR TITLE
fix(ci): comprehensive — stale dates, browser-use version, unused TS imports, workflow triggers

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -318,8 +318,8 @@
         "ref": "main",
         "sha": "af9911e626dd1406295b20c8e4d80f52ff3d8266"
       },
-      "description": "Full-platform browser automation for Claude Code. v1.1.0: Thin wrapper over built-in BrowserUseServer \u2014 63% less code. Fix TCC downloads_path, per-PID Chrome profiles, graceful shutdown. 19 MCP tools, 5 skills.",
-      "version": "1.1.1",
+      "description": "Full-platform browser automation for Claude Code. v1.1.2: Re-fix oneOf schema rejection (browser-use#4211) lost in v1.1.0 rewrite \u2014 sanitize upstream tool schemas to strip oneOf/allOf/anyOf rejected by Claude API. 19 MCP tools, 5 skills.",
+      "version": "1.1.2",
       "author": {
         "name": "Jack Rudenko",
         "email": "i@madappgang.com",

--- a/.github/workflows/test-plugins.yml
+++ b/.github/workflows/test-plugins.yml
@@ -2,7 +2,6 @@ name: Test Plugins
 
 on:
   push:
-    branches: [main, fix/ci-type-errors-and-stale-test-date]
     paths:
       - 'tools/claudeup-core/**'
       - 'tools/pnpm-lock.yaml'
@@ -14,7 +13,6 @@ on:
       - 'scripts/sync-shared-deps.sh'
       - '.github/workflows/test-plugins.yml'
   pull_request:
-    branches: [main, fix/ci-type-errors-and-stale-test-date]
     paths:
       - 'tools/claudeup-core/**'
       - 'tools/pnpm-lock.yaml'

--- a/.github/workflows/test-stats.yml
+++ b/.github/workflows/test-stats.yml
@@ -2,12 +2,10 @@ name: Test Stats Plugin
 
 on:
   push:
-    branches: [main, fix/ci-type-errors-and-stale-test-date]
     paths:
       - 'plugins/stats/**'
       - '.github/workflows/test-stats.yml'
   pull_request:
-    branches: [main, fix/ci-type-errors-and-stale-test-date]
     paths:
       - 'plugins/stats/**'
       - '.github/workflows/test-stats.yml'

--- a/plugins/stats/tests/db.test.ts
+++ b/plugins/stats/tests/db.test.ts
@@ -35,7 +35,9 @@ describe("db", () => {
     }
   });
 
-  function makeSession(id: string, project = "/test/project", date = "2026-03-26"): SessionMetrics {
+  const TODAY = new Date().toISOString().slice(0, 10);
+
+  function makeSession(id: string, project = "/test/project", date = TODAY): SessionMetrics {
     return {
       session_id: id,
       date,
@@ -48,14 +50,14 @@ describe("db", () => {
           duration_ms: 50,
           success: true,
           activity_category: "research",
-          timestamp: "2026-03-26T10:00:00.000Z",
+          timestamp: `${date}T10:00:00.000Z`,
         },
         {
           tool_name: "Write",
           duration_ms: 30,
           success: true,
           activity_category: "coding",
-          timestamp: "2026-03-26T10:01:00.000Z",
+          timestamp: `${date}T10:01:00.000Z`,
         },
       ],
       activity_counts: {
@@ -193,9 +195,8 @@ describe("db", () => {
 
   test("getSessionSummary returns aggregate stats", () => {
     const db = openDb(dbPath);
-    const today = new Date().toISOString().slice(0, 10);
-    insertSession(db, makeSession("s1", "/test/project", today));
-    insertSession(db, makeSession("s2", "/test/project", today));
+    insertSession(db, makeSession("s1", "/test/project", TODAY));
+    insertSession(db, makeSession("s2", "/test/project", TODAY));
 
     const summary = getSessionSummary(db, 7, "/test/project");
     expect(summary.session_count).toBe(2);
@@ -229,7 +230,7 @@ describe("db", () => {
     insertToolCalls(db, metrics.tool_calls, "old-session");
 
     // Insert a recent session
-    const recent = makeSession("recent-session", "/test/project", "2026-03-26");
+    const recent = makeSession("recent-session", "/test/project", TODAY);
     insertSession(db, recent);
 
     const { deletedCount } = deleteOldSessions(db, 90);

--- a/plugins/stats/tests/integration.test.ts
+++ b/plugins/stats/tests/integration.test.ts
@@ -62,6 +62,10 @@ import type {
 // Shared test helpers
 // ──────────────────────────────────────────────────────────────────────────────
 
+const TODAY = new Date().toISOString().slice(0, 10);
+const YESTERDAY = new Date(Date.now() - 86_400_000).toISOString().slice(0, 10);
+const TWO_DAYS_AGO = new Date(Date.now() - 2 * 86_400_000).toISOString().slice(0, 10);
+
 function makeTempDir(): string {
   const dir = join(tmpdir(), `stats-integ-${randomUUID()}`);
   mkdirSync(dir, { recursive: true });
@@ -71,7 +75,7 @@ function makeTempDir(): string {
 function makeSession(
   id: string,
   project = "/test/project",
-  date = "2026-03-26",
+  date = TODAY,
   overrides: Partial<SessionMetrics> = {}
 ): SessionMetrics {
   return {
@@ -378,8 +382,8 @@ describe("Database: schema, CRUD, retention, queries", () => {
     const db = openDb(dbPath);
 
     // Insert 2 sessions with known tool counts
-    insertSession(db, makeSession("s1", "/test/project", "2026-03-26"));
-    insertSession(db, makeSession("s2", "/test/project", "2026-03-26"));
+    insertSession(db, makeSession("s1", "/test/project", TODAY));
+    insertSession(db, makeSession("s2", "/test/project", TODAY));
     insertToolCalls(db, makeSession("s1").tool_calls, "s1");
     insertToolCalls(db, makeSession("s2").tool_calls, "s2");
 
@@ -412,7 +416,7 @@ describe("Database: schema, CRUD, retention, queries", () => {
     // Old session (well beyond 90 days)
     insertSession(db, makeSession("old", "/test/project", "2024-01-01"));
     // Recent session
-    insertSession(db, makeSession("recent", "/test/project", "2026-03-26"));
+    insertSession(db, makeSession("recent", "/test/project", TODAY));
 
     const { deletedCount } = deleteOldSessions(db, 90);
 
@@ -443,7 +447,7 @@ describe("Database: schema, CRUD, retention, queries", () => {
 
   test("deleteOldSessions returns 0 when no sessions are old enough", () => {
     const db = openDb(dbPath);
-    insertSession(db, makeSession("recent", "/test/project", "2026-03-26"));
+    insertSession(db, makeSession("recent", "/test/project", TODAY));
 
     const { deletedCount } = deleteOldSessions(db, 90);
 
@@ -454,14 +458,14 @@ describe("Database: schema, CRUD, retention, queries", () => {
 
   test("getTopTools returns tools ranked by call count", () => {
     const db = openDb(dbPath);
-    insertSession(db, makeSession("s1", "/test/project", "2026-03-26"));
+    insertSession(db, makeSession("s1", "/test/project", TODAY));
 
     const calls: ToolCallRecord[] = [
-      { tool_name: "Read", duration_ms: 10, success: true, activity_category: "research", timestamp: "2026-03-26T10:00:00.000Z" },
-      { tool_name: "Read", duration_ms: 20, success: true, activity_category: "research", timestamp: "2026-03-26T10:01:00.000Z" },
-      { tool_name: "Read", duration_ms: 15, success: true, activity_category: "research", timestamp: "2026-03-26T10:02:00.000Z" },
-      { tool_name: "Write", duration_ms: 30, success: true, activity_category: "coding", timestamp: "2026-03-26T10:03:00.000Z" },
-      { tool_name: "Bash", duration_ms: 100, success: true, activity_category: "other", timestamp: "2026-03-26T10:04:00.000Z" },
+      { tool_name: "Read", duration_ms: 10, success: true, activity_category: "research", timestamp: `${TODAY}T10:00:00.000Z` },
+      { tool_name: "Read", duration_ms: 20, success: true, activity_category: "research", timestamp: `${TODAY}T10:01:00.000Z` },
+      { tool_name: "Read", duration_ms: 15, success: true, activity_category: "research", timestamp: `${TODAY}T10:02:00.000Z` },
+      { tool_name: "Write", duration_ms: 30, success: true, activity_category: "coding", timestamp: `${TODAY}T10:03:00.000Z` },
+      { tool_name: "Bash", duration_ms: 100, success: true, activity_category: "other", timestamp: `${TODAY}T10:04:00.000Z` },
     ];
     insertToolCalls(db, calls, "s1");
 
@@ -484,10 +488,10 @@ describe("Database: schema, CRUD, retention, queries", () => {
   test("getDurationTrend returns daily data in ASC date order", () => {
     const db = openDb(dbPath);
 
-    // Insert sessions on different dates
-    insertSession(db, makeSession("s1", "/test/project", "2026-03-24"));
-    insertSession(db, makeSession("s2", "/test/project", "2026-03-25"));
-    insertSession(db, makeSession("s3", "/test/project", "2026-03-26"));
+    // Insert sessions on different dates (all within the 14-day window)
+    insertSession(db, makeSession("s1", "/test/project", TWO_DAYS_AGO));
+    insertSession(db, makeSession("s2", "/test/project", YESTERDAY));
+    insertSession(db, makeSession("s3", "/test/project", TODAY));
 
     const trend = getDurationTrend(db, 14, "/test/project");
 

--- a/tools/claudeup-core/src/__tests__/integration/conventions-integration.test.ts
+++ b/tools/claudeup-core/src/__tests__/integration/conventions-integration.test.ts
@@ -32,7 +32,6 @@ import { tmpdir } from 'node:os';
 import {
   // Gitignore operations
   ensureGitignoreEntries,
-  removeGitignoreEntries,
   checkGitignoreEntries,
   // CLAUDE.md operations
   parseClaudeMdSections,

--- a/tools/claudeup-core/src/__tests__/unit/doctor.test.ts
+++ b/tools/claudeup-core/src/__tests__/unit/doctor.test.ts
@@ -10,7 +10,7 @@
  * with real plugin.json files. runDoctor is tested by mocking the registry.
  */
 
-import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { mkdtemp, rm, writeFile, readFile, mkdir } from 'node:fs/promises';
 import { existsSync } from 'node:fs';
 import { tmpdir } from 'node:os';

--- a/tools/claudeup-core/src/services/conventions-manager.ts
+++ b/tools/claudeup-core/src/services/conventions-manager.ts
@@ -14,7 +14,6 @@
  */
 
 import { readFile, writeFile, stat, rename, unlink, open } from 'node:fs/promises';
-import { existsSync } from 'node:fs';
 import { randomUUID } from 'node:crypto';
 import { dirname, basename, join, resolve } from 'node:path';
 import { homedir } from 'node:os';


### PR DESCRIPTION
## What failed and why

This PR is a single clean fix for **all four ongoing CI failure categories** identified by inspecting the source branch on 2026-05-09. The failures have been ongoing since at least 2026-04-12 and five earlier fix PRs (#28, #31, #32, #33, #34) covered overlapping subsets but were never merged.

---

### 1. Stale hardcoded dates — `Test Stats Plugin` (runs 24307096245, 24307096246, and continuing)

Both stats test files used `"2026-03-26"` as the default session date. As of today that date is **44 days in the past**, placing it outside the 7-day window used by `getSessionSummary`/`getTopTools` and the 14-day window used by `getDurationTrend`. Those functions return zero rows, causing every assertion on their output to fail.

**Fix:**
- `plugins/stats/tests/db.test.ts` — added `const TODAY` constant inside the `describe` block; changed `makeSession()` default from `"2026-03-26"` to `TODAY`; updated hardcoded timestamps in tool_calls to use `${date}T...`; replaced the hardcoded `"2026-03-26"` in the `deleteOldSessions` recent-session test with `TODAY`.
- `plugins/stats/tests/integration.test.ts` — added module-level `TODAY`/`YESTERDAY`/`TWO_DAYS_AGO` constants; changed `makeSession()` default to `TODAY`; updated all five time-windowed tests (`getSessionSummary`, two `deleteOldSessions`, `getTopTools`, `getDurationTrend`).

---

### 2. `browser-use` version mismatch — `Test Plugins` (marketplace-sync job)

`plugins/browser-use/plugin.json` is at `v1.1.2` but `.claude-plugin/marketplace.json` was still at `v1.1.1`. The `marketplace-sync` integration test catches exactly this drift:

```
AssertionError: Plugin browser-use: version mismatch - plugin.json has 1.1.2, marketplace.json has 1.1.1
```

**Fix:** bumped `browser-use` version to `1.1.2` and updated the description in `.claude-plugin/marketplace.json`.

---

### 3. Unused TypeScript imports — `Test Plugins` (typecheck step, TS6133)

`tsc --noEmit` fails with `noUnusedLocals` on three imports left behind after refactors:

| File | Unused import |
|------|--------------|
| `tools/claudeup-core/src/__tests__/integration/conventions-integration.test.ts` | `removeGitignoreEntries` |
| `tools/claudeup-core/src/__tests__/unit/doctor.test.ts` | `vi` |
| `tools/claudeup-core/src/services/conventions-manager.ts` | `existsSync` |

**Fix:** removed all three unused imports.

---

### 4. Hardcoded branch filters blocking CI on new branches (structural)

Both `test-plugins.yml` and `test-stats.yml` had:
```yaml
push:
  branches: [main, fix/ci-type-errors-and-stale-test-date]
pull_request:
  branches: [main, fix/ci-type-errors-and-stale-test-date]
```
Any new `fix/*` or `feat/*` branch was invisible to CI. Path filters already limit CI to relevant file changes.

**Fix:** removed the `branches` key from both triggers in both workflow files.

---

## Relationship to existing PRs

This PR supersedes PRs #28, #31, #32, #33, and #34, which addressed overlapping subsets of these issues. Those PRs can be closed.

## Files changed

| File | Change |
|------|--------|
| `plugins/stats/tests/db.test.ts` | TODAY constant; rolling dates in makeSession() and tests |
| `plugins/stats/tests/integration.test.ts` | TODAY/YESTERDAY/TWO_DAYS_AGO; rolling dates in 5 time-windowed tests |
| `.claude-plugin/marketplace.json` | browser-use 1.1.1 → 1.1.2 |
| `tools/claudeup-core/src/__tests__/integration/conventions-integration.test.ts` | remove unused `removeGitignoreEntries` |
| `tools/claudeup-core/src/__tests__/unit/doctor.test.ts` | remove unused `vi` |
| `tools/claudeup-core/src/services/conventions-manager.ts` | remove unused `existsSync` |
| `.github/workflows/test-plugins.yml` | remove hardcoded branch filter |
| `.github/workflows/test-stats.yml` | remove hardcoded branch filter |

https://claude.ai/code/session_01KyRuTjzN3sFuW6NeGrV9ju

---
_Generated by [Claude Code](https://claude.ai/code/session_01KyRuTjzN3sFuW6NeGrV9ju)_