### PR TITLE
fix(ci): rolling dates, browser-use 1.1.2, unused TS imports, unrestrict workflow triggers

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -318,8 +318,8 @@
         "ref": "main",
         "sha": "af9911e626dd1406295b20c8e4d80f52ff3d8266"
       },
-      "description": "Full-platform browser automation for Claude Code. v1.1.0: Thin wrapper over built-in BrowserUseServer \u2014 63% less code. Fix TCC downloads_path, per-PID Chrome profiles, graceful shutdown. 19 MCP tools, 5 skills.",
-      "version": "1.1.1",
+      "description": "Full-platform browser automation for Claude Code. v1.1.2: Re-fix oneOf schema rejection (browser-use#4211) lost in v1.1.0 rewrite \u2014 sanitize upstream tool schemas to strip oneOf/allOf/anyOf rejected by Claude API. 19 MCP tools, 5 skills.",
+      "version": "1.1.2",
       "author": {
         "name": "Jack Rudenko",
         "email": "i@madappgang.com",

--- a/.github/workflows/test-plugins.yml
+++ b/.github/workflows/test-plugins.yml
@@ -2,7 +2,6 @@ name: Test Plugins
 
 on:
   push:
-    branches: [main, fix/ci-type-errors-and-stale-test-date]
     paths:
       - 'tools/claudeup-core/**'
       - 'tools/pnpm-lock.yaml'
@@ -14,7 +13,6 @@ on:
       - 'scripts/sync-shared-deps.sh'
       - '.github/workflows/test-plugins.yml'
   pull_request:
-    branches: [main, fix/ci-type-errors-and-stale-test-date]
     paths:
       - 'tools/claudeup-core/**'
       - 'tools/pnpm-lock.yaml'

--- a/.github/workflows/test-stats.yml
+++ b/.github/workflows/test-stats.yml
@@ -2,12 +2,10 @@ name: Test Stats Plugin
 
 on:
   push:
-    branches: [main, fix/ci-type-errors-and-stale-test-date]
     paths:
       - 'plugins/stats/**'
       - '.github/workflows/test-stats.yml'
   pull_request:
-    branches: [main, fix/ci-type-errors-and-stale-test-date]
     paths:
       - 'plugins/stats/**'
       - '.github/workflows/test-stats.yml'

--- a/plugins/stats/tests/integration.test.ts
+++ b/plugins/stats/tests/integration.test.ts
@@ -62,6 +62,10 @@ import type {
 // Shared test helpers
 // ──────────────────────────────────────────────────────────────────────────────
 
+const TODAY = new Date().toISOString().slice(0, 10);
+const YESTERDAY = new Date(Date.now() - 86400000).toISOString().slice(0, 10);
+const TWO_DAYS_AGO = new Date(Date.now() - 2 * 86400000).toISOString().slice(0, 10);
+
 function makeTempDir(): string {
   const dir = join(tmpdir(), `stats-integ-${randomUUID()}`);
   mkdirSync(dir, { recursive: true });
@@ -71,7 +75,7 @@ function makeTempDir(): string {
 function makeSession(
   id: string,
   project = "/test/project",
-  date = "2026-03-26",
+  date = TODAY,
   overrides: Partial<SessionMetrics> = {}
 ): SessionMetrics {
   return {
@@ -378,8 +382,8 @@ describe("Database: schema, CRUD, retention, queries", () => {
     const db = openDb(dbPath);
 
     // Insert 2 sessions with known tool counts
-    insertSession(db, makeSession("s1", "/test/project", "2026-03-26"));
-    insertSession(db, makeSession("s2", "/test/project", "2026-03-26"));
+    insertSession(db, makeSession("s1", "/test/project", TODAY));
+    insertSession(db, makeSession("s2", "/test/project", TODAY));
     insertToolCalls(db, makeSession("s1").tool_calls, "s1");
     insertToolCalls(db, makeSession("s2").tool_calls, "s2");
 
@@ -454,14 +458,14 @@ describe("Database: schema, CRUD, retention, queries", () => {
 
   test("getTopTools returns tools ranked by call count", () => {
     const db = openDb(dbPath);
-    insertSession(db, makeSession("s1", "/test/project", "2026-03-26"));
+    insertSession(db, makeSession("s1", "/test/project", TODAY));
 
     const calls: ToolCallRecord[] = [
-      { tool_name: "Read", duration_ms: 10, success: true, activity_category: "research", timestamp: "2026-03-26T10:00:00.000Z" },
-      { tool_name: "Read", duration_ms: 20, success: true, activity_category: "research", timestamp: "2026-03-26T10:01:00.000Z" },
-      { tool_name: "Read", duration_ms: 15, success: true, activity_category: "research", timestamp: "2026-03-26T10:02:00.000Z" },
-      { tool_name: "Write", duration_ms: 30, success: true, activity_category: "coding", timestamp: "2026-03-26T10:03:00.000Z" },
-      { tool_name: "Bash", duration_ms: 100, success: true, activity_category: "other", timestamp: "2026-03-26T10:04:00.000Z" },
+      { tool_name: "Read", duration_ms: 10, success: true, activity_category: "research", timestamp: `${TODAY}T10:00:00.000Z` },
+      { tool_name: "Read", duration_ms: 20, success: true, activity_category: "research", timestamp: `${TODAY}T10:01:00.000Z` },
+      { tool_name: "Read", duration_ms: 15, success: true, activity_category: "research", timestamp: `${TODAY}T10:02:00.000Z` },
+      { tool_name: "Write", duration_ms: 30, success: true, activity_category: "coding", timestamp: `${TODAY}T10:03:00.000Z` },
+      { tool_name: "Bash", duration_ms: 100, success: true, activity_category: "other", timestamp: `${TODAY}T10:04:00.000Z` },
     ];
     insertToolCalls(db, calls, "s1");
 
@@ -485,9 +489,9 @@ describe("Database: schema, CRUD, retention, queries", () => {
     const db = openDb(dbPath);
 
     // Insert sessions on different dates
-    insertSession(db, makeSession("s1", "/test/project", "2026-03-24"));
-    insertSession(db, makeSession("s2", "/test/project", "2026-03-25"));
-    insertSession(db, makeSession("s3", "/test/project", "2026-03-26"));
+    insertSession(db, makeSession("s1", "/test/project", TWO_DAYS_AGO));
+    insertSession(db, makeSession("s2", "/test/project", YESTERDAY));
+    insertSession(db, makeSession("s3", "/test/project", TODAY));
 
     const trend = getDurationTrend(db, 14, "/test/project");
 

--- a/tools/claudeup-core/src/__tests__/integration/conventions-integration.test.ts
+++ b/tools/claudeup-core/src/__tests__/integration/conventions-integration.test.ts
@@ -32,7 +32,6 @@ import { tmpdir } from 'node:os';
 import {
   // Gitignore operations
   ensureGitignoreEntries,
-  removeGitignoreEntries,
   checkGitignoreEntries,
   // CLAUDE.md operations
   parseClaudeMdSections,

--- a/tools/claudeup-core/src/__tests__/unit/doctor.test.ts
+++ b/tools/claudeup-core/src/__tests__/unit/doctor.test.ts
@@ -10,7 +10,7 @@
  * with real plugin.json files. runDoctor is tested by mocking the registry.
  */
 
-import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { mkdtemp, rm, writeFile, readFile, mkdir } from 'node:fs/promises';
 import { existsSync } from 'node:fs';
 import { tmpdir } from 'node:os';

--- a/tools/claudeup-core/src/services/conventions-manager.ts
+++ b/tools/claudeup-core/src/services/conventions-manager.ts
@@ -14,7 +14,6 @@
  */
 
 import { readFile, writeFile, stat, rename, unlink, open } from 'node:fs/promises';
-import { existsSync } from 'node:fs';
 import { randomUUID } from 'node:crypto';
 import { dirname, basename, join, resolve } from 'node:path';
 import { homedir } from 'node:os';


### PR DESCRIPTION
## What failed and why

CI has been broken on `fix/ci-type-errors-and-stale-test-date` since approximately 2026-04-06. Four root causes confirmed by reading the source branch directly (runs 24307096245 / 24307096246).

---

### 1. Stale hardcoded dates — `Test Stats Plugin`

`plugins/stats/tests/integration.test.ts` used `"2026-03-26"` as the default session date in `makeSession()`. As of today (2026-05-15) that date is **50 days in the past**, outside the rolling windows used by:

| Test | Query window | Result |
|------|-------------|--------|
| `getSessionSummary returns correct averages and totals` | 7 days | 0 rows → assertion fails |
| `getTopTools returns tools ranked by call count` | 7 days | 0 rows → assertion fails |
| `getDurationTrend returns daily data in ASC date order` | 14 days | 0 rows → assertion fails |

**Fix:** Added module-level `TODAY`, `YESTERDAY`, `TWO_DAYS_AGO` constants. Updated `makeSession()` default and all three time-windowed tests to use these constants.

---

### 2. `browser-use` version mismatch — `Test Plugins` (marketplace-sync)

`plugins/browser-use/plugin.json` is at `v1.1.2` but `.claude-plugin/marketplace.json` was still at `v1.1.1`. The `marketplace-sync` integration test catches this drift:

```
AssertionError: Plugin browser-use: version mismatch - plugin.json has 1.1.2, marketplace.json has 1.1.1
```

**Fix:** Bumped `browser-use` version to `1.1.2` and updated description in `marketplace.json`.

---

### 3. Unused TypeScript imports — `Test Plugins` (typecheck, TS6133)

`tsc --noEmit` fails under `noUnusedLocals` for three imports left behind after refactors:

| File | Unused import |
|------|--------------|
| `tools/claudeup-core/src/__tests__/integration/conventions-integration.test.ts` | `removeGitignoreEntries` |
| `tools/claudeup-core/src/__tests__/unit/doctor.test.ts` | `vi` |
| `tools/claudeup-core/src/services/conventions-manager.ts` | `existsSync` |

**Fix:** Removed all three unused imports.

---

### 4. Hardcoded branch filters blocking CI on all other branches

Both `test-plugins.yml` and `test-stats.yml` had:
```yaml
push:
  branches: [main, fix/ci-type-errors-and-stale-test-date]
pull_request:
  branches: [main, fix/ci-type-errors-and-stale-test-date]
```
Any new `fix/*` or `feat/*` branch was invisible to CI. This is why PRs #22, #23, #28, #31, #32, #33, #34, and #149 all lacked test CI runs (only GitGuardian fired). Path filters already limit CI to relevant file changes.

**Fix:** Removed the `branches` key from both triggers in both workflow files.

---

## Files changed

| File | Change |
|------|--------|
| `plugins/stats/tests/integration.test.ts` | TODAY/YESTERDAY/TWO_DAYS_AGO constants; rolling dates in 3 time-windowed tests |
| `.claude-plugin/marketplace.json` | browser-use 1.1.1 → 1.1.2, description updated |
| `tools/claudeup-core/src/__tests__/integration/conventions-integration.test.ts` | remove unused `removeGitignoreEntries` |
| `tools/claudeup-core/src/__tests__/unit/doctor.test.ts` | remove unused `vi` |
| `tools/claudeup-core/src/services/conventions-manager.ts` | remove unused `existsSync` |
| `.github/workflows/test-plugins.yml` | remove hardcoded branch filter |
| `.github/workflows/test-stats.yml` | remove hardcoded branch filter |

## Relationship to existing PRs

This PR addresses the same root causes as PRs #22, #23, #24, #28, #31, #32, #33, #34, and #149. Those PRs can be closed once this one is merged.

https://claude.ai/code/session_01HoPmTGL1q8oQ8BHqN8m2ZB

---
_Generated by [Claude Code](https://claude.ai/code/session_01HoPmTGL1q8oQ8BHqN8m2ZB)_