### PR TITLE
fix(stats/db.test): use rolling TODAY date — prevent CI failure ~2026-06-24

### DIFF
--- a/plugins/stats/tests/db.test.ts
+++ b/plugins/stats/tests/db.test.ts
@@ -18,6 +18,8 @@ import {
 import type { SessionMetrics, ToolCallRecord } from "../lib/types.ts";
 
 describe("db", () => {
+  const TODAY = new Date().toISOString().slice(0, 10);
+
   let tempDir: string;
   let dbPath: string;
 
@@ -35,7 +37,7 @@ describe("db", () => {
     }
   });
 
-  function makeSession(id: string, project = "/test/project", date = "2026-03-26"): SessionMetrics {
+  function makeSession(id: string, project = "/test/project", date = TODAY): SessionMetrics {
     return {
       session_id: id,
       date,
@@ -229,7 +231,7 @@ describe("db", () => {
     insertToolCalls(db, metrics.tool_calls, "old-session");
 
     // Insert a recent session
-    const recent = makeSession("recent-session", "/test/project", "2026-03-26");
+    const recent = makeSession("recent-session", "/test/project", TODAY);
     insertSession(db, recent);
 
     const { deletedCount } = deleteOldSessions(db, 90);


### PR DESCRIPTION
## What this fixes

`plugins/stats/tests/db.test.ts` had two places where `"2026-03-26"` was used as the date for a "recent" session in the `deleteOldSessions` retention test:

1. The `makeSession()` default parameter: `date = "2026-03-26"`
2. The explicit call in the test: `makeSession("recent-session", "/test/project", "2026-03-26")`

As of 2026-05-21 that date is **56 days old** — within the 90-day retention window, so the test currently passes. But around **2026-06-24** (90 days after 2026-03-26) the date will cross the threshold, the "recent" session will be deleted, and the test will fail:

```
expected deletedCount = 1  (old-session only)
got     deletedCount = 2   (both sessions deleted)
```

## Fix

Added `const TODAY = new Date().toISOString().slice(0, 10)` inside the `describe` block and replaced the two hardcoded occurrences — identical pattern to the fix already applied in `integration.test.ts` by PR #180 (this PR's base).

## Relationship to other PRs

This PR is stacked directly on **PR #180** (`fix/ci-24307096245`), which is the comprehensive CI fix with all 13 checks green. This is a single-commit addendum to that PR.

If PR #180 is merged first, re-target this PR to `fix/ci-type-errors-and-stale-test-date`.

https://claude.ai/code/session_01GWnvn27e7vi4p3xCNyFVqM


---
_Generated by [Claude Code](https://claude.ai/code/session_01GWnvn27e7vi4p3xCNyFVqM)_