### PR TITLE
fix(stats/integration.test): use rolling TODAY date — prevent CI failure ~2026-06-24

### DIFF
--- a/plugins/stats/tests/integration.test.ts
+++ b/plugins/stats/tests/integration.test.ts
@@ -416,7 +416,7 @@ describe("Database: schema, CRUD, retention, queries", () => {
     // Old session (well beyond 90 days)
     insertSession(db, makeSession("old", "/test/project", "2024-01-01"));
     // Recent session
-    insertSession(db, makeSession("recent", "/test/project", "2026-03-26"));
+    insertSession(db, makeSession("recent", "/test/project", TODAY));
 
     const { deletedCount } = deleteOldSessions(db, 90);
 
@@ -447,7 +447,7 @@ describe("Database: schema, CRUD, retention, queries", () => {
 
   test("deleteOldSessions returns 0 when no sessions are old enough", () => {
     const db = openDb(dbPath);
-    insertSession(db, makeSession("recent", "/test/project", "2026-03-26"));
+    insertSession(db, makeSession("recent", "/test/project", TODAY));
 
     const { deletedCount } = deleteOldSessions(db, 90);
 


### PR DESCRIPTION
## What this fixes

`plugins/stats/tests/integration.test.ts` had two `deleteOldSessions` retention tests using `"2026-03-26"` as the date for a "recent" session:

1. **"deleteOldSessions removes sessions beyond retention window"** — inserts an old session (`2024-01-01`) and a recent session (`"2026-03-26"`), expects `deletedCount = 1`. Once `2026-03-26` crosses 90 days old (~2026-06-24), both sessions will be deleted and `deletedCount` will be 2 → **test fails**.

2. **"deleteOldSessions returns 0 when no sessions are old enough"** — inserts only the `"2026-03-26"` session, expects `deletedCount = 0`. After ~2026-06-24, that session will be deleted → **test fails**.

As of today (2026-05-23) `"2026-03-26"` is 58 days old — within the 90-day window, so tests currently pass. They will fail in approximately **32 days**.

## Fix

Replaced both hardcoded `"2026-03-26"` occurrences with the `TODAY` constant already defined at the top of the file — the same pattern applied to `db.test.ts` by the companion PR #214.

## Relationship to other PRs

This PR is stacked directly on **PR #180** (`fix/ci-24307096245`), the comprehensive CI fix with all 13 checks green.

- **PR #214** (`fix/ci-db-test-rolling-dates`) — fixes the same class of issue in `db.test.ts`, but does not touch `integration.test.ts`. This PR fills that gap.
- If PR #180 is merged first, re-target this PR to `fix/ci-type-errors-and-stale-test-date`.

https://claude.ai/code/session_018a2oNcRBTHviPcedKmyroE

---
_Generated by [Claude Code](https://claude.ai/code/session_018a2oNcRBTHviPcedKmyroE)_