### PR TITLE
fix(ci): resolve test failures from TS unused imports, stale dates, and version drift

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -319,7 +319,7 @@
         "sha": "af9911e626dd1406295b20c8e4d80f52ff3d8266"
       },
       "description": "Full-platform browser automation for Claude Code. v1.1.0: Thin wrapper over built-in BrowserUseServer \u2014 63% less code. Fix TCC downloads_path, per-PID Chrome profiles, graceful shutdown. 19 MCP tools, 5 skills.",
-      "version": "1.1.1",
+      "version": "1.1.2",
       "author": {
         "name": "Jack Rudenko",
         "email": "i@madappgang.com",

--- a/.github/workflows/test-plugins.yml
+++ b/.github/workflows/test-plugins.yml
@@ -2,7 +2,6 @@ name: Test Plugins
 
 on:
   push:
-    branches: [main, fix/ci-type-errors-and-stale-test-date]
     paths:
       - 'tools/claudeup-core/**'
       - 'tools/pnpm-lock.yaml'
@@ -14,7 +13,6 @@ on:
       - 'scripts/sync-shared-deps.sh'
       - '.github/workflows/test-plugins.yml'
   pull_request:
-    branches: [main, fix/ci-type-errors-and-stale-test-date]
     paths:
       - 'tools/claudeup-core/**'
       - 'tools/pnpm-lock.yaml'

--- a/.github/workflows/test-stats.yml
+++ b/.github/workflows/test-stats.yml
@@ -2,12 +2,10 @@ name: Test Stats Plugin
 
 on:
   push:
-    branches: [main, fix/ci-type-errors-and-stale-test-date]
     paths:
       - 'plugins/stats/**'
       - '.github/workflows/test-stats.yml'
   pull_request:
-    branches: [main, fix/ci-type-errors-and-stale-test-date]
     paths:
       - 'plugins/stats/**'
       - '.github/workflows/test-stats.yml'

--- a/plugins/stats/tests/db.test.ts
+++ b/plugins/stats/tests/db.test.ts
@@ -17,6 +17,8 @@ import {
 } from "../lib/db.ts";
 import type { SessionMetrics, ToolCallRecord } from "../lib/types.ts";
 
+const TODAY = new Date().toISOString().slice(0, 10);
+
 describe("db", () => {
   let tempDir: string;
   let dbPath: string;
@@ -229,7 +231,7 @@ describe("db", () => {
     insertToolCalls(db, metrics.tool_calls, "old-session");
 
     // Insert a recent session
-    const recent = makeSession("recent-session", "/test/project", "2026-03-26");
+    const recent = makeSession("recent-session", "/test/project", TODAY);
     insertSession(db, recent);
 
     const { deletedCount } = deleteOldSessions(db, 90);

--- a/plugins/stats/tests/integration.test.ts
+++ b/plugins/stats/tests/integration.test.ts
@@ -416,7 +416,7 @@ describe("Database: schema, CRUD, retention, queries", () => {
     // Old session (well beyond 90 days)
     insertSession(db, makeSession("old", "/test/project", "2024-01-01"));
     // Recent session
-    insertSession(db, makeSession("recent", "/test/project", "2026-03-26"));
+    insertSession(db, makeSession("recent", "/test/project", TODAY));
 
     const { deletedCount } = deleteOldSessions(db, 90);
 
@@ -447,7 +447,7 @@ describe("Database: schema, CRUD, retention, queries", () => {
 
   test("deleteOldSessions returns 0 when no sessions are old enough", () => {
     const db = openDb(dbPath);
-    insertSession(db, makeSession("recent", "/test/project", "2026-03-26"));
+    insertSession(db, makeSession("recent", "/test/project", TODAY));
 
     const { deletedCount } = deleteOldSessions(db, 90);
 

--- a/plugins/stats/tests/integration.test.ts
+++ b/plugins/stats/tests/integration.test.ts
@@ -58,6 +58,10 @@ import type {
   SessionRow,
 } from "../lib/types.ts";
 
+const TODAY = new Date().toISOString().split("T")[0];
+const YESTERDAY = new Date(Date.now() - 86_400_000).toISOString().split("T")[0];
+const TWO_DAYS_AGO = new Date(Date.now() - 2 * 86_400_000).toISOString().split("T")[0];
+
 // ──────────────────────────────────────────────────────────────────────────────
 // Shared test helpers
 // ──────────────────────────────────────────────────────────────────────────────
@@ -378,10 +382,10 @@ describe("Database: schema, CRUD, retention, queries", () => {
     const db = openDb(dbPath);
 
     // Insert 2 sessions with known tool counts
-    insertSession(db, makeSession("s1", "/test/project", "2026-03-26"));
-    insertSession(db, makeSession("s2", "/test/project", "2026-03-26"));
-    insertToolCalls(db, makeSession("s1").tool_calls, "s1");
-    insertToolCalls(db, makeSession("s2").tool_calls, "s2");
+    insertSession(db, makeSession("s1", "/test/project", TODAY));
+    insertSession(db, makeSession("s2", "/test/project", TODAY));
+    insertToolCalls(db, makeSession("s1", "/test/project", TODAY).tool_calls, "s1");
+    insertToolCalls(db, makeSession("s2", "/test/project", TODAY).tool_calls, "s2");
 
     const summary = getSessionSummary(db, 7, "/test/project");
 
@@ -454,14 +458,14 @@ describe("Database: schema, CRUD, retention, queries", () => {
 
   test("getTopTools returns tools ranked by call count", () => {
     const db = openDb(dbPath);
-    insertSession(db, makeSession("s1", "/test/project", "2026-03-26"));
+    insertSession(db, makeSession("s1", "/test/project", TODAY));
 
     const calls: ToolCallRecord[] = [
-      { tool_name: "Read", duration_ms: 10, success: true, activity_category: "research", timestamp: "2026-03-26T10:00:00.000Z" },
-      { tool_name: "Read", duration_ms: 20, success: true, activity_category: "research", timestamp: "2026-03-26T10:01:00.000Z" },
-      { tool_name: "Read", duration_ms: 15, success: true, activity_category: "research", timestamp: "2026-03-26T10:02:00.000Z" },
-      { tool_name: "Write", duration_ms: 30, success: true, activity_category: "coding", timestamp: "2026-03-26T10:03:00.000Z" },
-      { tool_name: "Bash", duration_ms: 100, success: true, activity_category: "other", timestamp: "2026-03-26T10:04:00.000Z" },
+      { tool_name: "Read", duration_ms: 10, success: true, activity_category: "research", timestamp: `${TODAY}T10:00:00.000Z` },
+      { tool_name: "Read", duration_ms: 20, success: true, activity_category: "research", timestamp: `${TODAY}T10:01:00.000Z` },
+      { tool_name: "Read", duration_ms: 15, success: true, activity_category: "research", timestamp: `${TODAY}T10:02:00.000Z` },
+      { tool_name: "Write", duration_ms: 30, success: true, activity_category: "coding", timestamp: `${TODAY}T10:03:00.000Z` },
+      { tool_name: "Bash", duration_ms: 100, success: true, activity_category: "other", timestamp: `${TODAY}T10:04:00.000Z` },
     ];
     insertToolCalls(db, calls, "s1");
 
@@ -485,9 +489,9 @@ describe("Database: schema, CRUD, retention, queries", () => {
     const db = openDb(dbPath);
 
     // Insert sessions on different dates
-    insertSession(db, makeSession("s1", "/test/project", "2026-03-24"));
-    insertSession(db, makeSession("s2", "/test/project", "2026-03-25"));
-    insertSession(db, makeSession("s3", "/test/project", "2026-03-26"));
+    insertSession(db, makeSession("s1", "/test/project", TWO_DAYS_AGO));
+    insertSession(db, makeSession("s2", "/test/project", YESTERDAY));
+    insertSession(db, makeSession("s3", "/test/project", TODAY));
 
     const trend = getDurationTrend(db, 14, "/test/project");
 

--- a/tools/claudeup-core/src/__tests__/integration/conventions-integration.test.ts
+++ b/tools/claudeup-core/src/__tests__/integration/conventions-integration.test.ts
@@ -32,7 +32,6 @@ import { tmpdir } from 'node:os';
 import {
   // Gitignore operations
   ensureGitignoreEntries,
-  removeGitignoreEntries,
   checkGitignoreEntries,
   // CLAUDE.md operations
   parseClaudeMdSections,

--- a/tools/claudeup-core/src/__tests__/unit/doctor.test.ts
+++ b/tools/claudeup-core/src/__tests__/unit/doctor.test.ts
@@ -10,7 +10,7 @@
  * with real plugin.json files. runDoctor is tested by mocking the registry.
  */
 
-import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { mkdtemp, rm, writeFile, readFile, mkdir } from 'node:fs/promises';
 import { existsSync } from 'node:fs';
 import { tmpdir } from 'node:os';

--- a/tools/claudeup-core/src/services/conventions-manager.ts
+++ b/tools/claudeup-core/src/services/conventions-manager.ts
@@ -14,7 +14,6 @@
  */
 
 import { readFile, writeFile, stat, rename, unlink, open } from 'node:fs/promises';
-import { existsSync } from 'node:fs';
 import { randomUUID } from 'node:crypto';
 import { dirname, basename, join, resolve } from 'node:path';
 import { homedir } from 'node:os';


### PR DESCRIPTION
## What failed

CI runs 26430492914 and 26430494516 on PR #32 (`fix/ci-workflow-trigger-broadening`).

The `test (22)` job fails because `pnpm typecheck` runs `tsc --noEmit` with `noUnusedLocals`, triggering TS6133 errors.

## Fixes in this PR

### 1. TS6133 unused import — `vi` in doctor.test.ts
`tools/claudeup-core/src/__tests__/unit/doctor.test.ts` imported `vi` from `vitest` but never called it. Removed from import list.

### 2. TS6133 unused import — `existsSync` in conventions-manager.ts
`tools/claudeup-core/src/services/conventions-manager.ts` imported `existsSync` from `node:fs` but all file reads use `readFileOrEmpty` (catches ENOENT) and `stat` from `node:fs/promises`. Removed the unused import.

### 3. TS6133 unused import — `removeGitignoreEntries` in conventions-integration.test.ts
The integration test imported `removeGitignoreEntries` but only called `ensureGitignoreEntries` and `checkGitignoreEntries`. Removed from import block.

### 4. Rolling date constants in stats integration tests
`plugins/stats/tests/integration.test.ts` had hardcoded `"2026-03-26"` dates (now 62 days ago). Three tests — `getSessionSummary`, `getTopTools`, `getDurationTrend` — use rolling-window queries (`WHERE date >= today - N days`). Sessions outside the window return zero rows, causing assertion failures. Added `TODAY`, `YESTERDAY`, `TWO_DAYS_AGO` constants and updated those three tests.

### 5. Marketplace version drift — browser-use 1.1.1 → 1.1.2
`plugins/browser-use/plugin.json` is at `1.1.2` but `.claude-plugin/marketplace.json` still showed `1.1.1`. The marketplace-sync integration test catches this drift. Bumped to match.

### 6. Workflow trigger broadening
Both `test-plugins.yml` and `test-stats.yml` had hardcoded `branches: [main, fix/ci-type-errors-and-stale-test-date]` allowlists, making CI invisible on any other branch. Removed both `branches:` blocks; existing `paths:` filters already limit runs to relevant file changes.

### 7. Fix `deleteOldSessions` retention-test time-bomb (2026-05-27)
The `deleteOldSessions` "recent session" tests in both `integration.test.ts` and `db.test.ts` used the hardcoded date `"2026-03-26"` as the "recent" session. As of today that date is 62 days old — still within the 90-day retention window so tests pass now. But around **2026-06-24** (28 days away) it will cross the threshold and be deleted, breaking:
- `integration.test.ts`: "deleteOldSessions removes sessions beyond retention window" (deletedCount 1→2)
- `integration.test.ts`: "deleteOldSessions returns 0 when no sessions are old enough" (deletedCount 0→1)
- `db.test.ts`: "deleteOldSessions removes rows older than retention window" (deletedCount 1→2)

Replaced all three hardcoded occurrences with `TODAY`. Added `TODAY` constant to `db.test.ts` (already present in `integration.test.ts`).

## Note
PR #180 (`fix/ci-24307096245`) covers the same issues and has all 13 checks green since 2026-05-15. This PR is an equivalent fresh fix targeting `fix/ci-type-errors-and-stale-test-date`.

https://claude.ai/code/session_01PTSUGNYRk1Y2NH4Qkwik67
