### PR TITLE
fix(ci): 2 remaining unused TS imports + browser-use 1.1.2 + db.test rolling date

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -54,7 +54,7 @@
         "ref": "main",
         "sha": "af9911e626dd1406295b20c8e4d80f52ff3d8266"
       },
-      "description": "Multi-model collaboration, orchestration, and workflow patterns. v3.1.2: Fix internal model leaked to claudish \u2014 filter sentinel before external dispatch.",
+      "description": "Multi-model collaboration, orchestration, and workflow patterns. v3.1.2: Fix internal model leaked to claudish — filter sentinel before external dispatch.",
       "version": "3.1.2",
       "author": {
         "name": "Jack Rudenko",
@@ -89,7 +89,7 @@
         "ref": "main",
         "sha": "af9911e626dd1406295b20c8e4d80f52ff3d8266"
       },
-      "description": "Create, implement, and review Claude Code agents and commands with multi-model validation, LLM performance tracking, and session-based artifact isolation. v1.6.1: Fix manifest schema \u2014 agents paths, hooks format.",
+      "description": "Create, implement, and review Claude Code agents and commands with multi-model validation, LLM performance tracking, and session-based artifact isolation. v1.6.1: Fix manifest schema — agents paths, hooks format.",
       "version": "1.6.1",
       "author": {
         "name": "Jack Rudenko",
@@ -210,7 +210,7 @@
         "ref": "main",
         "sha": "af9911e626dd1406295b20c8e4d80f52ff3d8266"
       },
-      "description": "Context-Driven Development workflow inspired by Gemini Conductor. v2.1.3: Fix manifest schema \u2014 commands paths, add skills registration.",
+      "description": "Context-Driven Development workflow inspired by Gemini Conductor. v2.1.3: Fix manifest schema — commands paths, add skills registration.",
       "version": "2.1.3",
       "author": {
         "name": "Jack Rudenko",
@@ -241,7 +241,7 @@
         "ref": "main",
         "sha": "af9911e626dd1406295b20c8e4d80f52ff3d8266"
       },
-      "description": "Universal development assistant. v2.6.0: self-learning Stop hook \u2014 automated session learning with LLM classifier, background daemon, /dev:learn --apply/--prune.",
+      "description": "Universal development assistant. v2.6.0: self-learning Stop hook — automated session learning with LLM classifier, background daemon, /dev:learn --apply/--prune.",
       "version": "2.7.0",
       "author": {
         "name": "Jack Rudenko",
@@ -290,7 +290,7 @@
         "ref": "main",
         "sha": "af9911e626dd1406295b20c8e4d80f52ff3d8266"
       },
-      "description": "Adaptive statusline \u2014 always-visible bars, background highlights for critical states, provider-aware model display, vim mode, diff stats, compaction count, memory usage. v2.1.0: Prominent reset countdowns when rate-limited, process memory display.",
+      "description": "Adaptive statusline — always-visible bars, background highlights for critical states, provider-aware model display, vim mode, diff stats, compaction count, memory usage. v2.1.0: Prominent reset countdowns when rate-limited, process memory display.",
       "version": "2.1.0",
       "author": {
         "name": "Jack Rudenko",
@@ -318,8 +318,8 @@
         "ref": "main",
         "sha": "af9911e626dd1406295b20c8e4d80f52ff3d8266"
       },
-      "description": "Full-platform browser automation for Claude Code. v1.1.0: Thin wrapper over built-in BrowserUseServer \u2014 63% less code. Fix TCC downloads_path, per-PID Chrome profiles, graceful shutdown. 19 MCP tools, 5 skills.",
-      "version": "1.1.1",
+      "description": "Full-platform browser automation for Claude Code. v1.1.2: Re-fix oneOf schema rejection (browser-use#4211) lost in v1.1.0 rewrite — sanitize upstream tool schemas to strip oneOf/allOf/anyOf rejected by Claude API. 19 MCP tools, 5 skills.",
+      "version": "1.1.2",
       "author": {
         "name": "Jack Rudenko",
         "email": "i@madappgang.com",
@@ -382,7 +382,7 @@
         "ref": "main",
         "sha": "af9911e626dd1406295b20c8e4d80f52ff3d8266"
       },
-      "description": "Interactive terminal integration for Claude Code. v4.0.0: agentic-first rewrite \u2014 single Go tmux-mcp binary replaces ht-mcp + npm tmux-mcp. New agentic tools (start-and-watch, watch-pane, run-in-repl, pane-state) eliminate all polling loops. 5 skills, 9 commands, 1 agent.",
+      "description": "Interactive terminal integration for Claude Code. v4.0.0: agentic-first rewrite — single Go tmux-mcp binary replaces ht-mcp + npm tmux-mcp. New agentic tools (start-and-watch, watch-pane, run-in-repl, pane-state) eliminate all polling loops. 5 skills, 9 commands, 1 agent.",
       "version": "4.0.2",
       "author": {
         "name": "Jack Rudenko",
@@ -442,7 +442,7 @@
         "ref": "main",
         "sha": "af9911e626dd1406295b20c8e4d80f52ff3d8266"
       },
-      "description": "Kanban board view for task management. v1.2.0: Word-wrapped titles, full-width boards, even column distribution. Visual board with 5 columns, task dependencies (cycle-safe), priority indicators, WIP limits. Shares tasks.json with GTD plugin \u2014 works standalone or alongside GTD.",
+      "description": "Kanban board view for task management. v1.2.0: Word-wrapped titles, full-width boards, even column distribution. Visual board with 5 columns, task dependencies (cycle-safe), priority indicators, WIP limits. Shares tasks.json with GTD plugin — works standalone or alongside GTD.",
       "version": "1.2.0",
       "author": {
         "name": "Jack Rudenko",

--- a/plugins/stats/tests/db.test.ts
+++ b/plugins/stats/tests/db.test.ts
@@ -17,6 +17,8 @@ import {
 } from "../lib/db.ts";
 import type { SessionMetrics, ToolCallRecord } from "../lib/types.ts";
 
+const TODAY = new Date().toISOString().slice(0, 10);
+
 describe("db", () => {
   let tempDir: string;
   let dbPath: string;
@@ -35,7 +37,7 @@ describe("db", () => {
     }
   });
 
-  function makeSession(id: string, project = "/test/project", date = "2026-03-26"): SessionMetrics {
+  function makeSession(id: string, project = "/test/project", date = TODAY): SessionMetrics {
     return {
       session_id: id,
       date,
@@ -48,14 +50,14 @@ describe("db", () => {
           duration_ms: 50,
           success: true,
           activity_category: "research",
-          timestamp: "2026-03-26T10:00:00.000Z",
+          timestamp: `${date}T10:00:00.000Z`,
         },
         {
           tool_name: "Write",
           duration_ms: 30,
           success: true,
           activity_category: "coding",
-          timestamp: "2026-03-26T10:01:00.000Z",
+          timestamp: `${date}T10:01:00.000Z`,
         },
       ],
       activity_counts: {
@@ -228,8 +230,8 @@ describe("db", () => {
     insertSession(db, metrics);
     insertToolCalls(db, metrics.tool_calls, "old-session");
 
-    // Insert a recent session
-    const recent = makeSession("recent-session", "/test/project", "2026-03-26");
+    // Insert a recent session using TODAY so this test never becomes a time-bomb
+    const recent = makeSession("recent-session", "/test/project", TODAY);
     insertSession(db, recent);
 
     const { deletedCount } = deleteOldSessions(db, 90);

--- a/tools/claudeup-core/src/__tests__/unit/doctor.test.ts
+++ b/tools/claudeup-core/src/__tests__/unit/doctor.test.ts
@@ -10,7 +10,7 @@
  * with real plugin.json files. runDoctor is tested by mocking the registry.
  */
 
-import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { mkdtemp, rm, writeFile, readFile, mkdir } from 'node:fs/promises';
 import { existsSync } from 'node:fs';
 import { tmpdir } from 'node:os';

--- a/tools/claudeup-core/src/services/conventions-manager.ts
+++ b/tools/claudeup-core/src/services/conventions-manager.ts
@@ -14,7 +14,6 @@
  */
 
 import { readFile, writeFile, stat, rename, unlink, open } from 'node:fs/promises';
-import { existsSync } from 'node:fs';
 import { randomUUID } from 'node:crypto';
 import { dirname, basename, join, resolve } from 'node:path';
 import { homedir } from 'node:os';


### PR DESCRIPTION
## What failed

CI runs **26430494516** and **26430492914** on PR #32 (`fix/ci-workflow-trigger-broadening`).

The 2026-05-26 commit to that branch fixed rolling dates in `integration.test.ts` and removed the `removeGitignoreEntries` unused import from `conventions-integration.test.ts`, but left two more TS6133 errors — so `test (22)` (the Node 22 matrix job running `pnpm typecheck`) still fails.

Once the TS check was unblocked, the next failure would be the `marketplace-sync` integration test catching a version drift.

---

## Root causes fixed

### 1. TS6133 — unused `vi` import in `doctor.test.ts`

`tools/claudeup-core/src/__tests__/unit/doctor.test.ts` imported `vi` from `vitest` but no test in the file calls `vi.mock()`, `vi.fn()`, or `vi.spyOn()`. `tsc --noEmit` with `noUnusedLocals` flags it as TS6133.

**Fix:** Removed `vi` from the vitest import line.

### 2. TS6133 — unused `existsSync` import in `conventions-manager.ts`

`tools/claudeup-core/src/services/conventions-manager.ts` imported `existsSync` from `node:fs` but the function body uses `readFileOrEmpty` (which catches ENOENT internally) and `stat` from `node:fs/promises` — `existsSync` is never called.

**Fix:** Removed the `import { existsSync } from 'node:fs'` line entirely.

### 3. `browser-use` version mismatch (marketplace-sync)

`plugins/browser-use/plugin.json` is at `1.1.2` but `.claude-plugin/marketplace.json` still showed `1.1.1`. The `marketplace-sync` integration test catches exactly this drift and would fail as the next error after the TS check was fixed.

**Fix:** Bumped `browser-use` to `1.1.2` and updated the description to match `plugin.json`.

### 4. Time-bomb in `db.test.ts` `deleteOldSessions` test (proactive)

`plugins/stats/tests/db.test.ts` used the hardcoded date `"2026-03-26"` as the "recent" session in the `deleteOldSessions` retention test. As of 2026-05-29 that date is 64 days old — within the 90-day window so the test currently passes. But around **2026-06-24** it crosses the threshold, the "recent" session gets deleted, and `deletedCount` becomes 2 instead of 1.

**Fix:** Added a module-level `const TODAY` constant and replaced the hardcoded date with `TODAY` — same pattern already in `integration.test.ts`.

---

## Files changed

| File | Change |
|------|--------|
| `tools/claudeup-core/src/__tests__/unit/doctor.test.ts` | Remove unused `vi` from vitest import |
| `tools/claudeup-core/src/services/conventions-manager.ts` | Remove unused `existsSync` from node:fs import |
| `.claude-plugin/marketplace.json` | `browser-use` version `1.1.1` → `1.1.2`, description updated |
| `plugins/stats/tests/db.test.ts` | Add `TODAY` constant; use `TODAY` in `deleteOldSessions` recent-session test |

## Relationship to other PRs

- **PR #32** (`fix/ci-workflow-trigger-broadening`) — this PR is stacked directly on its head. If #32 is merged first, re-target to `fix/ci-type-errors-and-stale-test-date`.
- **PR #236** (`fix/ci-26430492914`) — covers the same root causes but on a different branch stack. Both are green fixes; whichever is merged first resolves the debt.
- **PR #180** (`fix/ci-24307096245`) — comprehensive fix, all 13 checks green since 2026-05-15. Also resolves these root causes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GJN2TSAwdh53VGKrtY2oCz)_