### PR TITLE
fix(marketplace): sync browser-use version to 1.1.2

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -319,7 +319,7 @@
         "sha": "af9911e626dd1406295b20c8e4d80f52ff3d8266"
       },
       "description": "Full-platform browser automation for Claude Code. v1.1.0: Thin wrapper over built-in BrowserUseServer \u2014 63% less code. Fix TCC downloads_path, per-PID Chrome profiles, graceful shutdown. 19 MCP tools, 5 skills.",
-      "version": "1.1.1",
+      "version": "1.1.2",
       "author": {
         "name": "Jack Rudenko",
         "email": "i@madappgang.com",


### PR DESCRIPTION
## What failed

CI runs [26822814536](https://github.com/MadAppGang/magus/actions/runs/26822814536) and [26822810251](https://github.com/MadAppGang/magus/actions/runs/26822810251) (and all earlier runs on `fix/ci-workflow-trigger-broadening`) fail at the **"Run integration tests"** step on both Node.js 20 and 22 with:

```
FAIL src/__tests__/integration/marketplace-sync.test.ts > marketplace-sync integration > real marketplace validation > should have version sync between plugin.json and marketplace.json
AssertionError: expected [ Array(1) ] to deeply equal []

+ Array [
+   "Plugin browser-use: version mismatch - plugin.json has 1.1.2, marketplace.json has 1.1.1",
+ ]
```

## Root cause

`plugins/browser-use/plugin.json` declares version `1.1.2`, but `.claude-plugin/marketplace.json` still has `1.1.1` for the `browser-use` entry. The `marketplace-sync` integration test (`tools/claudeup-core/src/__tests__/integration/marketplace-sync.test.ts:102`) asserts both files are in sync.

## Fix

One-line change: bump `browser-use` version in `marketplace.json` from `1.1.1` → `1.1.2` to match `plugin.json`.

## Test plan

- [ ] CI "Run integration tests" passes on Node.js 20
- [ ] CI "Run integration tests" passes on Node.js 22
- [ ] All other test steps remain green

---
_Generated by [Claude Code](https://claude.ai/code/session_01XNUhpZDz3S8TUtTGLqwzrE)_