### PR TITLE
fix(stats/db.test): rolling today date in deleteOldSessions — CI run 28830056466

### DIFF
--- a/plugins/stats/tests/db.test.ts
+++ b/plugins/stats/tests/db.test.ts
@@ -228,8 +228,9 @@ describe("db", () => {
     insertSession(db, metrics);
     insertToolCalls(db, metrics.tool_calls, "old-session");
 
-    // Insert a recent session
-    const recent = makeSession("recent-session", "/test/project", "2026-03-26");
+    // Insert a recent session — use rolling today so this test never becomes a time bomb
+    const todayDate = new Date().toISOString().slice(0, 10);
+    const recent = makeSession("recent-session", "/test/project", todayDate);
     insertSession(db, recent);
 
     const { deletedCount } = deleteOldSessions(db, 90);

--- a/plugins/stats/tests/db.test.ts
+++ b/plugins/stats/tests/db.test.ts
@@ -228,9 +228,9 @@ describe("db", () => {
     insertSession(db, metrics);
     insertToolCalls(db, metrics.tool_calls, "old-session");
 
-    // Insert a recent session — use rolling today so this test never becomes a time bomb
-    const todayDate = new Date().toISOString().slice(0, 10);
-    const recent = makeSession("recent-session", "/test/project", todayDate);
+    // Insert a recent session — rolling date avoids 90-day window expiry
+    const today = new Date().toISOString().split("T")[0];
+    const recent = makeSession("recent-session", "/test/project", today);
     insertSession(db, recent);
 
     const { deletedCount } = deleteOldSessions(db, 90);


### PR DESCRIPTION
## What failed

CI run [28830056466](https://github.com/MadAppGang/magus/actions/runs/28830056466) — **Test Stats Plugin** on branch `fix/ci-workflow-trigger-broadening` — fails with:

```
1 tests failed:
(fail) db > deleteOldSessions removes rows older than retention window [3.32ms]
```

83 of 84 tests pass; only this one fails.

## Root cause

`plugins/stats/tests/db.test.ts` inserts a "recent" session with a hardcoded date:

```typescript
const recent = makeSession("recent-session", "/test/project", "2026-03-26");
```

As of 2026-07-07, `"2026-03-26"` is **103 days ago** — past the 90-day retention window. `deleteOldSessions(db, 90)` correctly deletes it along with the intentionally-old `"2025-01-01"` session, returning `deletedCount = 2` instead of the expected `1`.

## Fix

Replace the hardcoded date with a dynamically computed today:

```typescript
// before
const recent = makeSession("recent-session", "/test/project", "2026-03-26");

// after
const todayDate = new Date().toISOString().slice(0, 10);
const recent = makeSession("recent-session", "/test/project", todayDate);
```

## Note on PR #381

PR #381 targeted the same bug but was branched from an older version of `fix/ci-workflow-trigger-broadening` that predated the `integration.test.ts` rolling-date fixes. That branch's own CI was failing on two different `integration.test.ts` tests. This PR is a clean, minimal fix branched directly from the current HEAD of `fix/ci-workflow-trigger-broadening`.

## Files changed

| File | Change |
|------|--------|
| `plugins/stats/tests/db.test.ts` | `deleteOldSessions` recent-session date: hardcoded `"2026-03-26"` → `new Date().toISOString().slice(0, 10)` |

---
_Generated by [Claude Code](https://claude.ai/code/session_01RV13AEJS9uvoGFkUysC37F)_