### PR TITLE
fix(stats/db.test): rolling date in deleteOldSessions test — unblocks PR #32 CI

### DIFF
--- a/plugins/stats/tests/db.test.ts
+++ b/plugins/stats/tests/db.test.ts
@@ -228,8 +228,9 @@ describe("db", () => {
     insertSession(db, metrics);
     insertToolCalls(db, metrics.tool_calls, "old-session");
 
-    // Insert a recent session
-    const recent = makeSession("recent-session", "/test/project", "2026-03-26");
+    // Insert a recent session — use rolling today so this test never becomes a time bomb
+    const todayDate = new Date().toISOString().slice(0, 10);
+    const recent = makeSession("recent-session", "/test/project", todayDate);
     insertSession(db, recent);
 
     const { deletedCount } = deleteOldSessions(db, 90);

--- a/plugins/stats/tests/db.test.ts
+++ b/plugins/stats/tests/db.test.ts
@@ -228,9 +228,9 @@ describe("db", () => {
     insertSession(db, metrics);
     insertToolCalls(db, metrics.tool_calls, "old-session");
 
-    // Insert a recent session — use rolling today so this test never becomes a time bomb
-    const todayDate = new Date().toISOString().slice(0, 10);
-    const recent = makeSession("recent-session", "/test/project", todayDate);
+    // Insert a recent session — rolling date avoids 90-day window expiry
+    const today = new Date().toISOString().split("T")[0];
+    const recent = makeSession("recent-session", "/test/project", today);
     insertSession(db, recent);
 
     const { deletedCount } = deleteOldSessions(db, 90);


### PR DESCRIPTION
## What failed

CI runs [28830056466](https://github.com/MadAppGang/magus/actions/runs/28830056466) and [28830054662](https://github.com/MadAppGang/magus/actions/runs/28830054662) on PR #32 (`fix/ci-workflow-trigger-broadening`) failed with:

```
(fail) db > deleteOldSessions removes rows older than retention window
Expected: 1
Received: 2
at plugins/stats/tests/db.test.ts:236
```

83 tests pass; 1 fails. The workflow trigger fix in PR #32 is sound — only this one time-bomb test is blocking it.

## Root cause

`plugins/stats/tests/db.test.ts` inserted a "recent" session with hardcoded date `"2026-03-26"`. As of the CI run date (2026-07-06), that date was **102 days in the past** — beyond the 90-day retention window. `deleteOldSessions(db, 90)` deleted both the intended old session and the supposedly-recent one, returning `deletedCount=2` instead of `1`.

## Fix

Replace the hardcoded date with a rolling `new Date()` call so the test can never expire:

```diff
- const recent = makeSession("recent-session", "/test/project", "2026-03-26");
+ const today = new Date().toISOString().split("T")[0];
+ const recent = makeSession("recent-session", "/test/project", today);
```

The old-session anchor (`"2025-01-01"`) stays fixed — it is always well outside 90 days and does not need to roll.

## Relationship to other PRs

This branch is stacked on PR #32 (`fix/ci-workflow-trigger-broadening`). Merging this into that branch will make PR #32's CI green so it can proceed to merge.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XJwVSx6fvSvR1xgPUwyuqb)_