### PR TITLE
fix(stats): rolling dates in both test files — resolve all CI time-bomb failures

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -54,7 +54,7 @@
         "ref": "main",
         "sha": "af9911e626dd1406295b20c8e4d80f52ff3d8266"
       },
-      "description": "Multi-model collaboration, orchestration, and workflow patterns. v3.1.2: Fix internal model leaked to claudish \u2014 filter sentinel before external dispatch.",
+      "description": "Multi-model collaboration, orchestration, and workflow patterns. v3.1.2: Fix internal model leaked to claudish — filter sentinel before external dispatch.",
       "version": "3.1.2",
       "author": {
         "name": "Jack Rudenko",
@@ -89,7 +89,7 @@
         "ref": "main",
         "sha": "af9911e626dd1406295b20c8e4d80f52ff3d8266"
       },
-      "description": "Create, implement, and review Claude Code agents and commands with multi-model validation, LLM performance tracking, and session-based artifact isolation. v1.6.1: Fix manifest schema \u2014 agents paths, hooks format.",
+      "description": "Create, implement, and review Claude Code agents and commands with multi-model validation, LLM performance tracking, and session-based artifact isolation. v1.6.1: Fix manifest schema — agents paths, hooks format.",
       "version": "1.6.1",
       "author": {
         "name": "Jack Rudenko",
@@ -210,7 +210,7 @@
         "ref": "main",
         "sha": "af9911e626dd1406295b20c8e4d80f52ff3d8266"
       },
-      "description": "Context-Driven Development workflow inspired by Gemini Conductor. v2.1.3: Fix manifest schema \u2014 commands paths, add skills registration.",
+      "description": "Context-Driven Development workflow inspired by Gemini Conductor. v2.1.3: Fix manifest schema — commands paths, add skills registration.",
       "version": "2.1.3",
       "author": {
         "name": "Jack Rudenko",
@@ -241,7 +241,7 @@
         "ref": "main",
         "sha": "af9911e626dd1406295b20c8e4d80f52ff3d8266"
       },
-      "description": "Universal development assistant. v2.6.0: self-learning Stop hook \u2014 automated session learning with LLM classifier, background daemon, /dev:learn --apply/--prune.",
+      "description": "Universal development assistant. v2.6.0: self-learning Stop hook — automated session learning with LLM classifier, background daemon, /dev:learn --apply/--prune.",
       "version": "2.7.0",
       "author": {
         "name": "Jack Rudenko",
@@ -290,7 +290,7 @@
         "ref": "main",
         "sha": "af9911e626dd1406295b20c8e4d80f52ff3d8266"
       },
-      "description": "Adaptive statusline \u2014 always-visible bars, background highlights for critical states, provider-aware model display, vim mode, diff stats, compaction count, memory usage. v2.1.0: Prominent reset countdowns when rate-limited, process memory display.",
+      "description": "Adaptive statusline — always-visible bars, background highlights for critical states, provider-aware model display, vim mode, diff stats, compaction count, memory usage. v2.1.0: Prominent reset countdowns when rate-limited, process memory display.",
       "version": "2.1.0",
       "author": {
         "name": "Jack Rudenko",
@@ -318,8 +318,8 @@
         "ref": "main",
         "sha": "af9911e626dd1406295b20c8e4d80f52ff3d8266"
       },
-      "description": "Full-platform browser automation for Claude Code. v1.1.0: Thin wrapper over built-in BrowserUseServer \u2014 63% less code. Fix TCC downloads_path, per-PID Chrome profiles, graceful shutdown. 19 MCP tools, 5 skills.",
-      "version": "1.1.1",
+      "description": "Full-platform browser automation for Claude Code. v1.1.0: Thin wrapper over built-in BrowserUseServer — 63% less code. Fix TCC downloads_path, per-PID Chrome profiles, graceful shutdown. 19 MCP tools, 5 skills.",
+      "version": "1.1.2",
       "author": {
         "name": "Jack Rudenko",
         "email": "i@madappgang.com",
@@ -382,7 +382,7 @@
         "ref": "main",
         "sha": "af9911e626dd1406295b20c8e4d80f52ff3d8266"
       },
-      "description": "Interactive terminal integration for Claude Code. v4.0.0: agentic-first rewrite \u2014 single Go tmux-mcp binary replaces ht-mcp + npm tmux-mcp. New agentic tools (start-and-watch, watch-pane, run-in-repl, pane-state) eliminate all polling loops. 5 skills, 9 commands, 1 agent.",
+      "description": "Interactive terminal integration for Claude Code. v4.0.0: agentic-first rewrite — single Go tmux-mcp binary replaces ht-mcp + npm tmux-mcp. New agentic tools (start-and-watch, watch-pane, run-in-repl, pane-state) eliminate all polling loops. 5 skills, 9 commands, 1 agent.",
       "version": "4.0.2",
       "author": {
         "name": "Jack Rudenko",
@@ -442,7 +442,7 @@
         "ref": "main",
         "sha": "af9911e626dd1406295b20c8e4d80f52ff3d8266"
       },
-      "description": "Kanban board view for task management. v1.2.0: Word-wrapped titles, full-width boards, even column distribution. Visual board with 5 columns, task dependencies (cycle-safe), priority indicators, WIP limits. Shares tasks.json with GTD plugin \u2014 works standalone or alongside GTD.",
+      "description": "Kanban board view for task management. v1.2.0: Word-wrapped titles, full-width boards, even column distribution. Visual board with 5 columns, task dependencies (cycle-safe), priority indicators, WIP limits. Shares tasks.json with GTD plugin — works standalone or alongside GTD.",
       "version": "1.2.0",
       "author": {
         "name": "Jack Rudenko",

--- a/.github/workflows/test-plugins.yml
+++ b/.github/workflows/test-plugins.yml
@@ -2,7 +2,6 @@ name: Test Plugins
 
 on:
   push:
-    branches: [main, fix/ci-type-errors-and-stale-test-date]
     paths:
       - 'tools/claudeup-core/**'
       - 'tools/pnpm-lock.yaml'
@@ -14,7 +13,6 @@ on:
       - 'scripts/sync-shared-deps.sh'
       - '.github/workflows/test-plugins.yml'
   pull_request:
-    branches: [main, fix/ci-type-errors-and-stale-test-date]
     paths:
       - 'tools/claudeup-core/**'
       - 'tools/pnpm-lock.yaml'

--- a/.github/workflows/test-stats.yml
+++ b/.github/workflows/test-stats.yml
@@ -2,12 +2,10 @@ name: Test Stats Plugin
 
 on:
   push:
-    branches: [main, fix/ci-type-errors-and-stale-test-date]
     paths:
       - 'plugins/stats/**'
       - '.github/workflows/test-stats.yml'
   pull_request:
-    branches: [main, fix/ci-type-errors-and-stale-test-date]
     paths:
       - 'plugins/stats/**'
       - '.github/workflows/test-stats.yml'

--- a/plugins/stats/tests/db.test.ts
+++ b/plugins/stats/tests/db.test.ts
@@ -228,8 +228,9 @@ describe("db", () => {
     insertSession(db, metrics);
     insertToolCalls(db, metrics.tool_calls, "old-session");
 
-    // Insert a recent session
-    const recent = makeSession("recent-session", "/test/project", "2026-03-26");
+    // Insert a recent session — use rolling today so this test never becomes a time bomb
+    const todayDate = new Date().toISOString().slice(0, 10);
+    const recent = makeSession("recent-session", "/test/project", todayDate);
     insertSession(db, recent);
 
     const { deletedCount } = deleteOldSessions(db, 90);

--- a/plugins/stats/tests/db.test.ts
+++ b/plugins/stats/tests/db.test.ts
@@ -228,9 +228,9 @@ describe("db", () => {
     insertSession(db, metrics);
     insertToolCalls(db, metrics.tool_calls, "old-session");
 
-    // Insert a recent session — use rolling today so this test never becomes a time bomb
-    const todayDate = new Date().toISOString().slice(0, 10);
-    const recent = makeSession("recent-session", "/test/project", todayDate);
+    // Insert a recent session — rolling date avoids 90-day window expiry
+    const today = new Date().toISOString().split("T")[0];
+    const recent = makeSession("recent-session", "/test/project", today);
     insertSession(db, recent);
 
     const { deletedCount } = deleteOldSessions(db, 90);

--- a/plugins/stats/tests/integration.test.ts
+++ b/plugins/stats/tests/integration.test.ts
@@ -417,8 +417,8 @@ describe("Database: schema, CRUD, retention, queries", () => {
 
     // Old session (well beyond 90 days)
     insertSession(db, makeSession("old", "/test/project", "2024-01-01"));
-    // Recent session
-    insertSession(db, makeSession("recent", "/test/project", "2026-03-26"));
+    // Recent session — use rolling TODAY so this test never becomes a time bomb
+    insertSession(db, makeSession("recent", "/test/project", TODAY));
 
     const { deletedCount } = deleteOldSessions(db, 90);
 
@@ -449,7 +449,8 @@ describe("Database: schema, CRUD, retention, queries", () => {
 
   test("deleteOldSessions returns 0 when no sessions are old enough", () => {
     const db = openDb(dbPath);
-    insertSession(db, makeSession("recent", "/test/project", "2026-03-26"));
+    // Use rolling TODAY so this test never becomes a time bomb
+    insertSession(db, makeSession("recent", "/test/project", TODAY));
 
     const { deletedCount } = deleteOldSessions(db, 90);
 

--- a/plugins/stats/tests/integration.test.ts
+++ b/plugins/stats/tests/integration.test.ts
@@ -58,6 +58,12 @@ import type {
   SessionRow,
 } from "../lib/types.ts";
 
+// Rolling date constants — tests that use 7- or 14-day rolling windows must
+// stay within those windows to get non-empty query results.
+const TODAY = new Date().toISOString().split("T")[0];
+const YESTERDAY = new Date(Date.now() - 86_400_000).toISOString().split("T")[0];
+const TWO_DAYS_AGO = new Date(Date.now() - 2 * 86_400_000).toISOString().split("T")[0];
+
 // ──────────────────────────────────────────────────────────────────────────────
 // Shared test helpers
 // ──────────────────────────────────────────────────────────────────────────────
@@ -378,8 +384,8 @@ describe("Database: schema, CRUD, retention, queries", () => {
     const db = openDb(dbPath);
 
     // Insert 2 sessions with known tool counts
-    insertSession(db, makeSession("s1", "/test/project", "2026-03-26"));
-    insertSession(db, makeSession("s2", "/test/project", "2026-03-26"));
+    insertSession(db, makeSession("s1", "/test/project", TODAY));
+    insertSession(db, makeSession("s2", "/test/project", TODAY));
     insertToolCalls(db, makeSession("s1").tool_calls, "s1");
     insertToolCalls(db, makeSession("s2").tool_calls, "s2");
 
@@ -454,14 +460,14 @@ describe("Database: schema, CRUD, retention, queries", () => {
 
   test("getTopTools returns tools ranked by call count", () => {
     const db = openDb(dbPath);
-    insertSession(db, makeSession("s1", "/test/project", "2026-03-26"));
+    insertSession(db, makeSession("s1", "/test/project", TODAY));
 
     const calls: ToolCallRecord[] = [
-      { tool_name: "Read", duration_ms: 10, success: true, activity_category: "research", timestamp: "2026-03-26T10:00:00.000Z" },
-      { tool_name: "Read", duration_ms: 20, success: true, activity_category: "research", timestamp: "2026-03-26T10:01:00.000Z" },
-      { tool_name: "Read", duration_ms: 15, success: true, activity_category: "research", timestamp: "2026-03-26T10:02:00.000Z" },
-      { tool_name: "Write", duration_ms: 30, success: true, activity_category: "coding", timestamp: "2026-03-26T10:03:00.000Z" },
-      { tool_name: "Bash", duration_ms: 100, success: true, activity_category: "other", timestamp: "2026-03-26T10:04:00.000Z" },
+      { tool_name: "Read", duration_ms: 10, success: true, activity_category: "research", timestamp: `${TODAY}T10:00:00.000Z` },
+      { tool_name: "Read", duration_ms: 20, success: true, activity_category: "research", timestamp: `${TODAY}T10:01:00.000Z` },
+      { tool_name: "Read", duration_ms: 15, success: true, activity_category: "research", timestamp: `${TODAY}T10:02:00.000Z` },
+      { tool_name: "Write", duration_ms: 30, success: true, activity_category: "coding", timestamp: `${TODAY}T10:03:00.000Z` },
+      { tool_name: "Bash", duration_ms: 100, success: true, activity_category: "other", timestamp: `${TODAY}T10:04:00.000Z` },
     ];
     insertToolCalls(db, calls, "s1");
 
@@ -485,9 +491,9 @@ describe("Database: schema, CRUD, retention, queries", () => {
     const db = openDb(dbPath);
 
     // Insert sessions on different dates
-    insertSession(db, makeSession("s1", "/test/project", "2026-03-24"));
-    insertSession(db, makeSession("s2", "/test/project", "2026-03-25"));
-    insertSession(db, makeSession("s3", "/test/project", "2026-03-26"));
+    insertSession(db, makeSession("s1", "/test/project", TWO_DAYS_AGO));
+    insertSession(db, makeSession("s2", "/test/project", YESTERDAY));
+    insertSession(db, makeSession("s3", "/test/project", TODAY));
 
     const trend = getDurationTrend(db, 14, "/test/project");
 

--- a/tools/claudeup-core/src/__tests__/integration/conventions-integration.test.ts
+++ b/tools/claudeup-core/src/__tests__/integration/conventions-integration.test.ts
@@ -32,7 +32,6 @@ import { tmpdir } from 'node:os';
 import {
   // Gitignore operations
   ensureGitignoreEntries,
-  removeGitignoreEntries,
   checkGitignoreEntries,
   // CLAUDE.md operations
   parseClaudeMdSections,

--- a/tools/claudeup-core/src/__tests__/unit/doctor.test.ts
+++ b/tools/claudeup-core/src/__tests__/unit/doctor.test.ts
@@ -10,7 +10,7 @@
  * with real plugin.json files. runDoctor is tested by mocking the registry.
  */
 
-import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { mkdtemp, rm, writeFile, readFile, mkdir } from 'node:fs/promises';
 import { existsSync } from 'node:fs';
 import { tmpdir } from 'node:os';

--- a/tools/claudeup-core/src/services/conventions-manager.ts
+++ b/tools/claudeup-core/src/services/conventions-manager.ts
@@ -14,7 +14,6 @@
  */
 
 import { readFile, writeFile, stat, rename, unlink, open } from 'node:fs/promises';
-import { existsSync } from 'node:fs';
 import { randomUUID } from 'node:crypto';
 import { dirname, basename, join, resolve } from 'node:path';
 import { homedir } from 'node:os';


### PR DESCRIPTION
## What broke and why

CI runs on branches targeting `fix/ci-type-errors-and-stale-test-date` have been failing since ~2026-06-24 with:

```
(fail) db > deleteOldSessions removes rows older than retention window
Expected: 1  Received: 2
```

**Root cause:** `plugins/stats/tests/db.test.ts` and `integration.test.ts` both used hardcoded date `"2026-03-26"` as the "recent session" in the `deleteOldSessions` retention tests. As of 2026-06-24 that date crossed the 90-day retention threshold, so `deleteOldSessions(db, 90)` started deleting it too — returning `deletedCount=2` (both sessions deleted) instead of `1`.

The same stale date caused integration tests `deleteOldSessions removes sessions beyond retention window` and `deleteOldSessions returns 0 when no sessions are old enough` to fail on branches where `integration.test.ts` hadn't been updated yet.

**Why this accumulated:** The CI workflow only ran on PRs targeting specific branches — so fix branches were invisible to CI until PR #32 broadened the triggers. Once CI started running on all branches, the stale-date failures became visible across the full PR stack.

## What this PR fixes

| File | Change |
|------|--------|
| `plugins/stats/tests/db.test.ts` | Replace hardcoded `"2026-03-26"` in `deleteOldSessions` test with `new Date().toISOString().split('T')[0]` (rolling today) |
| `plugins/stats/tests/integration.test.ts` | Same rolling-date fix for the two `deleteOldSessions` tests; also adds `TODAY`/`YESTERDAY`/`TWO_DAYS_AGO` constants used by `getTopTools` and `getDurationTrend` tests |
| `.github/workflows/test-stats.yml` | Remove hardcoded branch filters — CI now runs on any branch/PR touching `plugins/stats/` |
| `.github/workflows/test-plugins.yml` | Same trigger broadening |
| `plugins/browser-use/` | Bump to v1.1.2 (marketplace version sync) |
| `tools/claudeup-core/` | Remove unused TS imports that were causing `TS6133` failures |

## Affected CI runs

- Run [28830056466](https://github.com/MadAppGang/magus/actions/runs/28830056466) — PR #32 merge commit, `db.test.ts` stale date, `deletedCount=2 ≠ 1`
- Run [28830054662](https://github.com/MadAppGang/magus/actions/runs/28830054662) — same PR, same failure
- Run [28787588299](https://github.com/MadAppGang/magus/actions/runs/28787588299) — `integration.test.ts` stale dates, 2 failing tests
- Run [28787574550](https://github.com/MadAppGang/magus/actions/runs/28787574550) — same

## Note on open PRs

There are currently 16+ open PRs all targeting this same stack of issues. Many of them are stacked on each other and represent earlier fix attempts. Merging this PR into `fix/ci-type-errors-and-stale-test-date` would make CI green on the base branch, allowing the stacked PRs to be resolved or closed.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NGynAxwu77BocMK4AUDL7b)_