### PR TITLE
fix(ci): unused TS imports + rolling stats dates + browser-use 1.1.2

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -319,7 +319,7 @@
         "sha": "af9911e626dd1406295b20c8e4d80f52ff3d8266"
       },
       "description": "Full-platform browser automation for Claude Code. v1.1.0: Thin wrapper over built-in BrowserUseServer \u2014 63% less code. Fix TCC downloads_path, per-PID Chrome profiles, graceful shutdown. 19 MCP tools, 5 skills.",
-      "version": "1.1.1",
+      "version": "1.1.2",
       "author": {
         "name": "Jack Rudenko",
         "email": "i@madappgang.com",

--- a/plugins/stats/tests/db.test.ts
+++ b/plugins/stats/tests/db.test.ts
@@ -35,7 +35,13 @@ describe("db", () => {
     }
   });
 
-  function makeSession(id: string, project = "/test/project", date = "2026-03-26"): SessionMetrics {
+  function today(offsetDays = 0): string {
+    const d = new Date();
+    d.setDate(d.getDate() - offsetDays);
+    return d.toISOString().slice(0, 10);
+  }
+
+  function makeSession(id: string, project = "/test/project", date = today()): SessionMetrics {
     return {
       session_id: id,
       date,
@@ -48,14 +54,14 @@ describe("db", () => {
           duration_ms: 50,
           success: true,
           activity_category: "research",
-          timestamp: "2026-03-26T10:00:00.000Z",
+          timestamp: `${date}T10:00:00.000Z`,
         },
         {
           tool_name: "Write",
           duration_ms: 30,
           success: true,
           activity_category: "coding",
-          timestamp: "2026-03-26T10:01:00.000Z",
+          timestamp: `${date}T10:01:00.000Z`,
         },
       ],
       activity_counts: {
@@ -229,7 +235,7 @@ describe("db", () => {
     insertToolCalls(db, metrics.tool_calls, "old-session");
 
     // Insert a recent session
-    const recent = makeSession("recent-session", "/test/project", "2026-03-26");
+    const recent = makeSession("recent-session");
     insertSession(db, recent);
 
     const { deletedCount } = deleteOldSessions(db, 90);

--- a/plugins/stats/tests/integration.test.ts
+++ b/plugins/stats/tests/integration.test.ts
@@ -68,10 +68,16 @@ function makeTempDir(): string {
   return dir;
 }
 
+function today(offsetDays = 0): string {
+  const d = new Date();
+  d.setDate(d.getDate() - offsetDays);
+  return d.toISOString().slice(0, 10);
+}
+
 function makeSession(
   id: string,
   project = "/test/project",
-  date = "2026-03-26",
+  date = today(),
   overrides: Partial<SessionMetrics> = {}
 ): SessionMetrics {
   return {
@@ -113,7 +119,7 @@ function makeSessionRow(
 ): SessionRow {
   return {
     id,
-    date: "2026-03-26",
+    date: today(),
     project: "/test/project",
     duration_sec: 600,
     total_tool_calls: 10,
@@ -123,7 +129,7 @@ function makeSessionRow(
     testing_calls: 1,
     delegation_calls: 1,
     other_calls: 1,
-    created_at: "2026-03-26T10:00:00.000Z",
+    created_at: `${today()}T10:00:00.000Z`,
     ...overrides,
   };
 }
@@ -378,8 +384,8 @@ describe("Database: schema, CRUD, retention, queries", () => {
     const db = openDb(dbPath);
 
     // Insert 2 sessions with known tool counts
-    insertSession(db, makeSession("s1", "/test/project", "2026-03-26"));
-    insertSession(db, makeSession("s2", "/test/project", "2026-03-26"));
+    insertSession(db, makeSession("s1", "/test/project", today()));
+    insertSession(db, makeSession("s2", "/test/project", today()));
     insertToolCalls(db, makeSession("s1").tool_calls, "s1");
     insertToolCalls(db, makeSession("s2").tool_calls, "s2");
 
@@ -412,7 +418,7 @@ describe("Database: schema, CRUD, retention, queries", () => {
     // Old session (well beyond 90 days)
     insertSession(db, makeSession("old", "/test/project", "2024-01-01"));
     // Recent session
-    insertSession(db, makeSession("recent", "/test/project", "2026-03-26"));
+    insertSession(db, makeSession("recent", "/test/project", today()));
 
     const { deletedCount } = deleteOldSessions(db, 90);
 
@@ -443,7 +449,7 @@ describe("Database: schema, CRUD, retention, queries", () => {
 
   test("deleteOldSessions returns 0 when no sessions are old enough", () => {
     const db = openDb(dbPath);
-    insertSession(db, makeSession("recent", "/test/project", "2026-03-26"));
+    insertSession(db, makeSession("recent", "/test/project", today()));
 
     const { deletedCount } = deleteOldSessions(db, 90);
 
@@ -454,14 +460,14 @@ describe("Database: schema, CRUD, retention, queries", () => {
 
   test("getTopTools returns tools ranked by call count", () => {
     const db = openDb(dbPath);
-    insertSession(db, makeSession("s1", "/test/project", "2026-03-26"));
+    insertSession(db, makeSession("s1", "/test/project", today()));
 
     const calls: ToolCallRecord[] = [
-      { tool_name: "Read", duration_ms: 10, success: true, activity_category: "research", timestamp: "2026-03-26T10:00:00.000Z" },
-      { tool_name: "Read", duration_ms: 20, success: true, activity_category: "research", timestamp: "2026-03-26T10:01:00.000Z" },
-      { tool_name: "Read", duration_ms: 15, success: true, activity_category: "research", timestamp: "2026-03-26T10:02:00.000Z" },
-      { tool_name: "Write", duration_ms: 30, success: true, activity_category: "coding", timestamp: "2026-03-26T10:03:00.000Z" },
-      { tool_name: "Bash", duration_ms: 100, success: true, activity_category: "other", timestamp: "2026-03-26T10:04:00.000Z" },
+      { tool_name: "Read", duration_ms: 10, success: true, activity_category: "research", timestamp: `${today()}T10:00:00.000Z` },
+      { tool_name: "Read", duration_ms: 20, success: true, activity_category: "research", timestamp: `${today()}T10:01:00.000Z` },
+      { tool_name: "Read", duration_ms: 15, success: true, activity_category: "research", timestamp: `${today()}T10:02:00.000Z` },
+      { tool_name: "Write", duration_ms: 30, success: true, activity_category: "coding", timestamp: `${today()}T10:03:00.000Z` },
+      { tool_name: "Bash", duration_ms: 100, success: true, activity_category: "other", timestamp: `${today()}T10:04:00.000Z` },
     ];
     insertToolCalls(db, calls, "s1");
 
@@ -484,10 +490,10 @@ describe("Database: schema, CRUD, retention, queries", () => {
   test("getDurationTrend returns daily data in ASC date order", () => {
     const db = openDb(dbPath);
 
-    // Insert sessions on different dates
-    insertSession(db, makeSession("s1", "/test/project", "2026-03-24"));
-    insertSession(db, makeSession("s2", "/test/project", "2026-03-25"));
-    insertSession(db, makeSession("s3", "/test/project", "2026-03-26"));
+    // Insert sessions on different dates (all within 14-day window)
+    insertSession(db, makeSession("s1", "/test/project", today(-2)));
+    insertSession(db, makeSession("s2", "/test/project", today(-1)));
+    insertSession(db, makeSession("s3", "/test/project", today()));
 
     const trend = getDurationTrend(db, 14, "/test/project");
 

--- a/tools/claudeup-core/src/__tests__/integration/conventions-integration.test.ts
+++ b/tools/claudeup-core/src/__tests__/integration/conventions-integration.test.ts
@@ -32,7 +32,6 @@ import { tmpdir } from 'node:os';
 import {
   // Gitignore operations
   ensureGitignoreEntries,
-  removeGitignoreEntries,
   checkGitignoreEntries,
   // CLAUDE.md operations
   parseClaudeMdSections,

--- a/tools/claudeup-core/src/__tests__/unit/doctor.test.ts
+++ b/tools/claudeup-core/src/__tests__/unit/doctor.test.ts
@@ -10,7 +10,7 @@
  * with real plugin.json files. runDoctor is tested by mocking the registry.
  */
 
-import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { mkdtemp, rm, writeFile, readFile, mkdir } from 'node:fs/promises';
 import { existsSync } from 'node:fs';
 import { tmpdir } from 'node:os';

--- a/tools/claudeup-core/src/services/conventions-manager.ts
+++ b/tools/claudeup-core/src/services/conventions-manager.ts
@@ -14,7 +14,6 @@
  */
 
 import { readFile, writeFile, stat, rename, unlink, open } from 'node:fs/promises';
-import { existsSync } from 'node:fs';
 import { randomUUID } from 'node:crypto';
 import { dirname, basename, join, resolve } from 'node:path';
 import { homedir } from 'node:os';


### PR DESCRIPTION
## What failed

Three separate CI failures on the dev base branch (all in runs from 2026-08-08):

| Run | Workflow | Failure |
|-----|----------|---------|
| 31243617526 | Test Plugins (Node 20) | `marketplace-sync` integration test — version mismatch: plugin.json has 1.1.2, marketplace.json has 1.1.1 |
| 31243509806 | Test Plugins (Node 22) | TypeScript `tsc --noEmit` exits 2 — 3 unused import errors (TS6133) |
| 31243509802 | Test Stats Plugin | 5 DB query tests fail — hardcoded `"2026-03-26"` dates are now > 90 days in the past, outside every query window |

## Root causes and fixes

### 1. Unused TypeScript imports (TS6133)
Three imports declared but never used:

```
conventions-integration.test.ts(35,3): 'removeGitignoreEntries' is declared but its value is never read
doctor.test.ts(13,55): 'vi' is declared but its value is never read
conventions-manager.ts(17,1): 'existsSync' is declared but its value is never read
```

**Fix:** Remove each unused import.

### 2. Stale hardcoded dates in stats integration tests
Tests like `getSessionSummary`, `getTopTools`, `getDurationTrend`, and `deleteOldSessions` inserted sessions dated `"2026-03-26"` (now 143 days ago). DB queries filter by 7-day, 14-day, or 90-day windows — so all that data fell outside the window and tests got empty results.

**Fix:** Add a `today(offsetDays?)` helper and replace all hardcoded dates in the affected tests with rolling equivalents (`today()`, `today(-1)`, `today(-2)`).

### 3. browser-use version mismatch
`plugins/browser-use/plugin.json` declares version `1.1.2` but `.claude-plugin/marketplace.json` still listed `1.1.1`. The `marketplace-sync` integration test detects this mismatch.

**Fix:** Bump browser-use `version` in `marketplace.json` to `1.1.2`.

## Context: accumulated fix PRs

⚠️ There are currently 13+ open PRs targeting this base branch that attempt the same set of fixes. Each one had some incomplete or newly-introduced issue that prevented CI from going green. This PR addresses all three root causes together in a single commit. Please consider closing the stale fix PRs once this one is reviewed.

---
_Generated by [Claude Code](https://claude.ai/code/session_011QfPqmUaKfxDPmWvqmANoF)_